### PR TITLE
NativeSocket::write() may loop indefinitely

### DIFF
--- a/classes/Pheanstalk/Socket/NativeSocket.php
+++ b/classes/Pheanstalk/Socket/NativeSocket.php
@@ -36,17 +36,25 @@ class Pheanstalk_Socket_NativeSocket implements Pheanstalk_Socket
 	 */
 	public function write($data)
 	{
+		$WriteLengths = array();
 		for ($written = 0, $fwrite = 0; $written < strlen($data); $written += $fwrite)
 		{
 			$fwrite = fwrite($this->_socket, substr($data, $written));
 
+			$WriteLengths[] = $fwrite;
+			if( count( $WriteLengths ) === 6 )
+			{
+				array_shift( $WriteLengths );
+			}
+
+			if( count( $WriteLengths ) >= 5 && array_sum( $WriteLengths ) === 0 )
+			{
+				throw new Pheanstalk_Exception_SocketException( 'fwrite() returned 0; preventing infinite loop' );
+			}
+
 			if ($fwrite === false )
 			{
 				throw new Pheanstalk_Exception_SocketException('fwrite() returned false');
-			}
-			else if( $fwrite === 0 )
-			{
-				throw new Pheanstalk_Exception_SocketException( 'fwrite() returned 0; preventing infinite loop' );
 			}
 		}
 	}


### PR DESCRIPTION
Dev machine: Ubuntu 10.04 - PHP 5.3.2

When the socket was interrupted, fwrite returned 0 instead of false. I have not verified whether this is normal behavior. This affected my software when beanstalk died.

My first commit fixed the problem by adding if( $fwrite === 0 ), but because I can imagine this happening in real life, I changed my approach to check the length of the last 5 writes. If the sum of the write lengths is 0, an exception is thrown.
