### PR TITLE
Empty preg_match raises PHP warning

### DIFF
--- a/classes/Pheanstalk/Command/PutCommand.php
+++ b/classes/Pheanstalk/Command/PutCommand.php
@@ -103,7 +103,7 @@ class Pheanstalk_Command_PutCommand
 				$responseLine
 			));
 		}
-		elseif (preg_match())
+		else
 		{
 			throw new Pheanstalk_Exception(sprintf(
 				'Unhandled response: %s',


### PR DESCRIPTION
A tiny fix for PutCommand::parseResponse() if we get an unknown response
