### PR TITLE
using Zend_Config_Ini to store beanstalk connection value cause null valu

### DIFF
--- a/classes/Pheanstalk/Connection.php
+++ b/classes/Pheanstalk/Connection.php
@@ -41,7 +41,7 @@ class Pheanstalk_Connection
 	 */
 	public function __construct($hostname, $port, $connectTimeout = null)
 	{
-		if (is_null($connectTimeout))
+		if (is_null($connectTimeout) || !is_numeric($connectTimeout))
 			$connectTimeout = self::DEFAULT_CONNECT_TIMEOUT;
 
 		$this->_hostname = $hostname;


### PR DESCRIPTION
using Zend_Config_Ini to store beanstalk connection value cause null values to be return a "".

config.ini

---

[production]

beanstalk.host = "localhost"
beanstalk.port = "11300"
beanstalk.connectTimeout = null

[development : production]

---

the above will cause a connect error has the connectTimeout will be converted to "" and not null.

the above change checks if the connectTimeout is a valid number.
