### PR TITLE
Fixes an error when generating a phar

### DIFF
--- a/makephar.php
+++ b/makephar.php
@@ -7,7 +7,7 @@
     $bootstrapFile = file_get_contents(__DIR__ . '/pheanstalk_init.php');
     $bootstrapFile = str_replace('<?php', '', $bootstrapFile);
 
-    $stub .= "<?php" . PHP_EOL;
+    $stub  = "<?php" . PHP_EOL;
     $stub .= "Phar::mapPhar();" . PHP_EOL;
     $stub .= $bootstrapFile . PHP_EOL;
     $stub .= "__HALT_COMPILER();" . PHP_EOL;


### PR DESCRIPTION
The script `makephar.php` triggers an E_NOTICE because it attempts to concatenate a non-existent string variable. This one-character-difference patch stops the error.
