### PR TITLE
Autoload clause added in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,8 @@
     ],
     "require": {
         "php": ">=5.3.0"
+    },
+    "autoload": {
+        "psr-0": { "Pheanstalk": "classes" }
     }
 }


### PR DESCRIPTION
Adding `autoload` clause enables automatic generation of namespaces map (e.g. in Symfony 2.1).

There were related issues reported but they did not contain any code.
