### PR TITLE
Fix some build issues in build_phar.php

### DIFF
--- a/scripts/build_phar.php
+++ b/scripts/build_phar.php
@@ -55,10 +55,13 @@ function pheanstalk_phar_stub()
 {
 	$pheanstalkInit = BASE_DIR . '/pheanstalk_init.php';
 	printf("- Generating Phar stub based on %s\n", basename($pheanstalkInit));
+	$stub = file_get_contents($pheanstalkInit);
+	$stub = str_replace('<?php', '', $stub);
+	$stub = str_replace("dirname(__FILE__) . '/classes';", "'phar://' . __FILE__;", $stub);
 	return implode(array(
 		'<?php',
 		'Phar::mapPhar();',
-		str_replace('<?php', '', file_get_contents($pheanstalkInit)),
+		$stub,
 		'__HALT_COMPILER();'
 	), PHP_EOL);
 }


### PR DESCRIPTION
In the current master branch, the phar file generated from build phar was unable to find the class loader.  I made a few small tweaks to how it determines the include path for the classes.
