### PR TITLE
Kick a specific job by its ID, #51

### DIFF
--- a/classes/Pheanstalk.php
+++ b/classes/Pheanstalk.php
@@ -102,6 +102,18 @@ class Pheanstalk
 	}
 
 	/**
+	 * Kicks buried or delayed jobs into a 'ready' state.
+	 *
+	 * @param Pheanstalk_Job $job Pheanstalk_Job
+	 * @chainable
+	 */
+	public function kickJob($job)
+	{
+		$this->_dispatch(new Pheanstalk_Command_KickJobCommand($job));
+		return $this;
+	}
+
+	/**
 	 * The names of all tubes on the server.
 	 *
 	 * @return array

--- a/classes/Pheanstalk/Command/KickJobCommand.php
+++ b/classes/Pheanstalk/Command/KickJobCommand.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * The 'kick-job' command.
+ * Kicks a specific buried or delayed job into a 'ready' state.
+ *
+ * @author Matthieu Napoli
+ * @package Pheanstalk
+ * @licence http://www.opensource.org/licenses/mit-license.php
+ */
+class Pheanstalk_Command_KickJobCommand
+	extends Pheanstalk_Command_AbstractCommand
+	implements Pheanstalk_ResponseParser
+{
+	private $_job;
+
+	/**
+	 * @param Pheanstalk_Job $job Pheanstalk job
+	 */
+	public function __construct($job)
+	{
+		$this->_job = $job;
+	}
+
+	/* (non-phpdoc)
+	 * @see Pheanstalk_Command::getCommandLine()
+	 */
+	public function getCommandLine()
+	{
+		return 'kick-job '.$this->_job->getId();
+	}
+
+	/* (non-phpdoc)
+	 * @see Pheanstalk_ResponseParser::parseRespose()
+	 */
+	public function parseResponse($responseLine, $responseData)
+	{
+		if ($responseLine == Pheanstalk_Response::RESPONSE_NOT_FOUND)
+		{
+			throw new Pheanstalk_Exception_ServerException(sprintf(
+				'%s: Job %d does not exist or is not in a kickable state.',
+				$responseLine,
+				$this->_job->getId()
+			));
+		}
+		elseif ($responseLine == Pheanstalk_Response::RESPONSE_KICKED)
+		{
+			return $this->_createResponse(Pheanstalk_Response::RESPONSE_KICKED);
+		}
+		else
+		{
+			throw new Pheanstalk_Exception('Unhandled response: '.$responseLine);
+		}
+	}
+}

--- a/tests/Pheanstalk/CommandTest.php
+++ b/tests/Pheanstalk/CommandTest.php
@@ -58,6 +58,17 @@ class Pheanstalk_CommandTest
 		);
 	}
 
+	public function testKickJob()
+	{
+		$command = new Pheanstalk_Command_KickJobCommand($this->_mockJob(5));
+		$this->_assertCommandLine($command, 'kick-job 5');
+
+		$this->_assertResponse(
+			$command->getResponseParser()->parseResponse('KICKED', null),
+			Pheanstalk_Response::RESPONSE_KICKED
+		);
+	}
+
 	public function testListTubesWatched()
 	{
 		$command = new Pheanstalk_Command_ListTubesWatchedCommand();


### PR DESCRIPTION
Kick a specific job by its ID, #51

Implemented in Beanstalkd V1.8 (https://github.com/kr/beanstalkd/issues/120)
