### PR TITLE
Commands now take either a jobID or Pheanstalk_Job object.

### DIFF
--- a/classes/Pheanstalk/Command/BuryCommand.php
+++ b/classes/Pheanstalk/Command/BuryCommand.php
@@ -12,16 +12,16 @@ class Pheanstalk_Command_BuryCommand
     extends Pheanstalk_Command_AbstractCommand
     implements Pheanstalk_ResponseParser
 {
-    private $_job;
+    private $_jobId;
     private $_priority;
 
     /**
-     * @param object $job Pheanstalk_Job
+     * @param object $job Pheanstalk_Job or int $job
      * @param int $priority From 0 (most urgent) to 0xFFFFFFFF (least urgent)
      */
     public function __construct($job, $priority)
     {
-        $this->_job = $job;
+        $this->_jobId = is_object($job) ? $job->getId() : $job;
         $this->_priority = $priority;
     }
 
@@ -32,7 +32,7 @@ class Pheanstalk_Command_BuryCommand
     {
         return sprintf(
             'bury %u %u',
-            $this->_job->getId(),
+            $this->_jobId,
             $this->_priority
         );
     }
@@ -46,7 +46,7 @@ class Pheanstalk_Command_BuryCommand
             throw new Pheanstalk_Exception_ServerException(sprintf(
                 '%s: Job %u is not reserved or does not exist.',
                 $responseLine,
-                $this->_job->getId()
+                $this->_jobId
             ));
         } elseif ($responseLine == Pheanstalk_Response::RESPONSE_BURIED) {
             return $this->_createResponse(Pheanstalk_Response::RESPONSE_BURIED);

--- a/classes/Pheanstalk/Command/DeleteCommand.php
+++ b/classes/Pheanstalk/Command/DeleteCommand.php
@@ -12,14 +12,14 @@ class Pheanstalk_Command_DeleteCommand
     extends Pheanstalk_Command_AbstractCommand
     implements Pheanstalk_ResponseParser
 {
-    private $_job;
+    private $_jobId;
 
     /**
-     * @param object $job Pheanstalk_Job
+     * @param object $job Pheanstalk_Job or int $job
      */
     public function __construct($job)
     {
-        $this->_job = $job;
+        $this->_jobId = is_object($job) ? $job->getId() : $job;
     }
 
     /* (non-phpdoc)
@@ -27,7 +27,7 @@ class Pheanstalk_Command_DeleteCommand
      */
     public function getCommandLine()
     {
-        return 'delete '.$this->_job->getId();
+        return sprintf('delete %u', $this->_jobId);
     }
 
     /* (non-phpdoc)
@@ -38,7 +38,7 @@ class Pheanstalk_Command_DeleteCommand
         if ($responseLine == Pheanstalk_Response::RESPONSE_NOT_FOUND) {
             throw new Pheanstalk_Exception_ServerException(sprintf(
                 'Cannot delete job %u: %s',
-                $this->_job->getId(),
+                $this->_jobId,
                 $responseLine
             ));
         }

--- a/classes/Pheanstalk/Command/KickJobCommand.php
+++ b/classes/Pheanstalk/Command/KickJobCommand.php
@@ -16,14 +16,14 @@ class Pheanstalk_Command_KickJobCommand
 	extends Pheanstalk_Command_AbstractCommand
 	implements Pheanstalk_ResponseParser
 {
-	private $_job;
+	private $_jobId;
 
 	/**
 	 * @param Pheanstalk_Job $job Pheanstalk job
 	 */
 	public function __construct($job)
 	{
-		$this->_job = $job;
+		$this->_jobId = is_object($job) ? $job->getId() : $job;
 	}
 
 	/* (non-phpdoc)
@@ -31,7 +31,7 @@ class Pheanstalk_Command_KickJobCommand
 	 */
 	public function getCommandLine()
 	{
-		return 'kick-job '.$this->_job->getId();
+		return sprintf('kick-job %u', $this->_jobId);
 	}
 
 	/* (non-phpdoc)
@@ -42,9 +42,9 @@ class Pheanstalk_Command_KickJobCommand
 		if ($responseLine == Pheanstalk_Response::RESPONSE_NOT_FOUND)
 		{
 			throw new Pheanstalk_Exception_ServerException(sprintf(
-				'%s: Job %d does not exist or is not in a kickable state.',
+				'%s: Job %u does not exist or is not in a kickable state.',
 				$responseLine,
-				$this->_job->getId()
+				$this->_jobId
 			));
 		}
 		elseif ($responseLine == Pheanstalk_Response::RESPONSE_KICKED)

--- a/classes/Pheanstalk/Command/PeekCommand.php
+++ b/classes/Pheanstalk/Command/PeekCommand.php
@@ -35,6 +35,8 @@ class Pheanstalk_Command_PeekCommand
     {
         if (is_int($peekSubject) || ctype_digit($peekSubject)) {
             $this->_jobId = $peekSubject;
+        } elseif (is_object($peekSubject)) {
+            $this->_jobId = $peekSubject->getId();
         } elseif (in_array($peekSubject, $this->_subcommands)) {
             $this->_subcommand = $peekSubject;
         } else {

--- a/classes/Pheanstalk/Command/TouchCommand.php
+++ b/classes/Pheanstalk/Command/TouchCommand.php
@@ -17,14 +17,14 @@ class Pheanstalk_Command_TouchCommand
     extends Pheanstalk_Command_AbstractCommand
     implements Pheanstalk_ResponseParser
 {
-    private $_job;
+    private $_jobId;
 
     /**
-     * @param Pheanstalk_Job $job
+     * @param Pheanstalk_Job $job or $int $job
      */
     public function __construct($job)
     {
-        $this->_job = $job;
+        $this->_jobId = is_object($job) ? $job->getId() : $job;
     }
 
     /* (non-phpdoc)
@@ -32,7 +32,7 @@ class Pheanstalk_Command_TouchCommand
      */
     public function getCommandLine()
     {
-        return sprintf('touch %u', $this->_job->getId());
+        return sprintf('touch %u', $this->_jobId);
     }
 
     /* (non-phpdoc)
@@ -43,7 +43,7 @@ class Pheanstalk_Command_TouchCommand
         if ($responseLine == Pheanstalk_Response::RESPONSE_NOT_FOUND) {
             throw new Pheanstalk_Exception_ServerException(sprintf(
                 'Job %u %s: does not exist or is not reserved by client',
-                $this->_job->getId(),
+                $this->_jobId,
                 $responseLine
             ));
         }


### PR DESCRIPTION
Updated all commands that currently take a job object to also accept a job ID.
