### PR TITLE
improved Composer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ implemented.
   [1]: http://xph.us/software/beanstalkd/
   [2]: http://paul.annesley.cc/
   [3]: http://github.com/kr/beanstalkd/tree/v1.3/doc/protocol.txt?raw=true
-  [4]: http://semver.org/
 
 Installation with Composer
 -------------
@@ -28,10 +27,14 @@ Declare pheanstalk as a dependency in your projects `composer.json` file:
 ``` json
 {
   "require": {
-    "pda/pheanstalk": "dev-master"
+    "pda/pheanstalk": "$VERSION"
   }
 }
 ```
+
+Replace `$VERSION` with one of the stable versions available on
+[Packagist](https://packagist.org/packages/pda/pheanstalk) or `2.*@dev` to get
+the current development version for the 2.x Pheanstalk API.
 
 Usage Example
 -------------

--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,10 @@
         "psr-0": {
             "Pheanstalk": "classes/"
         }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.x-dev"
+        }
     }
 }


### PR DESCRIPTION
This PR just fixes to minor issues:
- We should not advocate using `dev-master` to users, or they create apps that **will break** at some point. Instead, using a stable version is more suitable (especially since there is a very recent one available). To not change the `README.md` all the time, the text just directs users to Packagist to pick whatever is stable at that moment.
- If someone really needs untested stuff, `dev-master` is still a bad idea (think of Pheanstalk 3.x with an incompatible API). This PR adds an alias for the master branch, so people can require the virtual version `2.x-dev` (or `2.*@dev`). When changing the API in master, one can simply open up an actual  `2.x` branch and everything continues to work.
