### PR TITLE
Accumulate read data in string instead of array.

### DIFF
--- a/src/Socket/NativeSocket.php
+++ b/src/Socket/NativeSocket.php
@@ -72,7 +72,7 @@ class NativeSocket implements Socket
     public function read($length)
     {
         $read = 0;
-        $parts = array();
+        $parts = '';
 
         while ($read < $length && !$this->_wrapper()->feof($this->_socket)) {
             $data = $this->_wrapper()
@@ -83,10 +83,10 @@ class NativeSocket implements Socket
             }
 
             $read += strlen($data);
-            $parts []= $data;
+            $parts .= $data;
         }
 
-        return implode($parts);
+        return $parts;
     }
 
     /* (non-phpdoc)


### PR DESCRIPTION
The array version uses a lot of memory.
