### PR TITLE
$_watching missing currently watched tubes with persistent connections

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,15 +1,20 @@
 {
-    "name": "pda/pheanstalk",
+    "name": "gabfl/pheanstalk",
     "type": "library",
-    "description": "PHP client for beanstalkd queue",
+    "description": "PHP client for beanstalkd queue, forked from pda/pheanstalk",
     "keywords": ["beanstalkd"],
-    "homepage": "https://github.com/pda/pheanstalk",
+    "homepage": "https://github.com/gabfl/pheanstalk",
     "license": "MIT",
     "authors": [
         {
             "name": "Paul Annesley",
             "email": "paul@annesley.cc",
             "homepage": "http://paul.annesley.cc/",
+            "role": "Developer"
+        },
+        {
+            "name": "Gabriel Bordeaux",
+            "homepage": "http://gab.lc/",
             "role": "Developer"
         }
     ],

--- a/composer.json
+++ b/composer.json
@@ -1,20 +1,15 @@
 {
-    "name": "gabfl/pheanstalk",
+    "name": "pda/pheanstalk",
     "type": "library",
-    "description": "PHP client for beanstalkd queue, forked from pda/pheanstalk",
+    "description": "PHP client for beanstalkd queue",
     "keywords": ["beanstalkd"],
-    "homepage": "https://github.com/gabfl/pheanstalk",
+    "homepage": "https://github.com/pda/pheanstalk",
     "license": "MIT",
     "authors": [
         {
             "name": "Paul Annesley",
             "email": "paul@annesley.cc",
             "homepage": "http://paul.annesley.cc/",
-            "role": "Developer"
-        },
-        {
-            "name": "Gabriel Bordeaux",
-            "homepage": "http://gab.lc/",
             "role": "Developer"
         }
     ],

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -180,7 +180,7 @@ class Connection
      *
      * @return bool
      */
-    public function getConnectPersist()
+    public function getConnectPersistent()
     {
         return $this->_connectPersistent;
     }

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -175,6 +175,16 @@ class Connection
         return $this->_port;
     }
 
+    /**
+     * Returns persistent connection state for this connection.
+     *
+     * @return bool
+     */
+    public function getConnectPersist()
+    {
+        return $this->_connectPersistent;
+    }
+
     // ----------------------------------------
 
     /**

--- a/src/Pheanstalk.php
+++ b/src/Pheanstalk.php
@@ -63,7 +63,7 @@ class Pheanstalk implements PheanstalkInterface
         if ($this->_connection->getConnectPersistent()) {
             $this->listTubesWatched(true);
         }
-        
+
         // Default
         if (!$this->_watching) {
             $this->_watching = array(PheanstalkInterface::DEFAULT_TUBE => true);

--- a/src/Pheanstalk.php
+++ b/src/Pheanstalk.php
@@ -60,7 +60,7 @@ class Pheanstalk implements PheanstalkInterface
     public function setWatching()
     {
         // If we have a persistent connection, retrieve list of tubes currently watched for this connection
-        if($this->_connection->getConnectPersist())
+        if($this->_connection->getConnectPersistent())
         {
             $this->listTubesWatched(true);
         }

--- a/src/Pheanstalk.php
+++ b/src/Pheanstalk.php
@@ -20,7 +20,7 @@ class Pheanstalk implements PheanstalkInterface
 
     private $_connection;
     private $_using = PheanstalkInterface::DEFAULT_TUBE;
-    private $_watching = array(PheanstalkInterface::DEFAULT_TUBE => true);
+    private $_watching;
 
     /**
      * @param string $host
@@ -31,6 +31,9 @@ class Pheanstalk implements PheanstalkInterface
     public function __construct($host, $port = PheanstalkInterface::DEFAULT_PORT, $connectTimeout = null, $connectPersistent = false)
     {
         $this->setConnection(new Connection($host, $port, $connectTimeout, $connectPersistent));
+        
+        // Set watching
+        $this->setWatching();
     }
 
     /**
@@ -49,6 +52,24 @@ class Pheanstalk implements PheanstalkInterface
     public function getConnection()
     {
         return $this->_connection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setWatching()
+    {
+        // If we have a persistent connection, retrieve list of tubes currently watched for this connection
+        if($this->_connection->getConnectPersist())
+        {
+            $this->listTubesWatched(true);
+        }
+        
+        // Default
+        if(!$this->_watching)
+        {
+            $this->_watching = array(PheanstalkInterface::DEFAULT_TUBE => true);
+        }
     }
 
     // ----------------------------------------

--- a/src/Pheanstalk.php
+++ b/src/Pheanstalk.php
@@ -31,7 +31,7 @@ class Pheanstalk implements PheanstalkInterface
     public function __construct($host, $port = PheanstalkInterface::DEFAULT_PORT, $connectTimeout = null, $connectPersistent = false)
     {
         $this->setConnection(new Connection($host, $port, $connectTimeout, $connectPersistent));
-        
+
         // Set watching
         $this->setWatching();
     }
@@ -60,14 +60,12 @@ class Pheanstalk implements PheanstalkInterface
     public function setWatching()
     {
         // If we have a persistent connection, retrieve list of tubes currently watched for this connection
-        if($this->_connection->getConnectPersistent())
-        {
+        if ($this->_connection->getConnectPersistent()) {
             $this->listTubesWatched(true);
         }
         
         // Default
-        if(!$this->_watching)
-        {
+        if (!$this->_watching) {
             $this->_watching = array(PheanstalkInterface::DEFAULT_TUBE => true);
         }
     }


### PR DESCRIPTION
When using `$connectPersistent=true`, the default declaration of `$_watching` (`array(PheanstalkInterface::DEFAULT_TUBE => true)`) is incorrect if a previous connection watched some other tubes (with `watch()` or `watchOnly()`).

This PR implements a method a method that forces a call to `listTubesWatched(true)` if the connection is persistent to ensure `$_watching` contains the correct list of currently watched tubes.

Without this bugfix, `watch()` and especially `watchOnly()` can watch more tubes than the one intended.
