### PR TITLE
Updated Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Usage Example
 
 use Pheanstalk\Pheanstalk;
 // Create using autodetection of socket implementation
-$pheanstalk = new Pheanstalk::create('127.0.0.1');
+$pheanstalk = Pheanstalk::create('127.0.0.1');
 
 // ----------------------------------------
 // producer (queues jobs)


### PR DESCRIPTION
Updated the usage example, removed the `new` statement because it causes an error since the command changed from `$pheanstalk = new Pheanstalk('127.0.0.1');` to `$pheanstalk = new Pheanstalk::create('127.0.0.1');`