### PR TITLE
- Add support for reserve-job. Added in beanstalkd 1.12+

### DIFF
--- a/src/Command/ReserveJobCommand.php
+++ b/src/Command/ReserveJobCommand.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Pheanstalk\Command;
+
+use Pheanstalk\Contract\ResponseInterface;
+use Pheanstalk\Contract\ResponseParserInterface;
+use Pheanstalk\Response\ArrayResponse;
+
+/**
+ * The 'reserve-job' command.
+ *
+ * Reserves/locks a specific job, new in beanstalkd 1.12+
+ */
+class ReserveJobCommand extends AbstractCommand implements ResponseParserInterface
+{
+    private int $job;
+    public function __construct(int $job)
+    {
+       $this->job = $job;
+    }
+    public function getCommandLine(): string
+    {
+        return sprintf('reserve-job %d', $this->job);
+    }
+
+    public function parseResponse(string $responseLine, ?string $responseData): ArrayResponse
+    {
+        if ($responseLine === ResponseInterface::RESPONSE_NOT_FOUND) {
+            throw new JobNotFoundException();
+        }
+
+        list($code, $id) = explode(' ', $responseLine);
+        return $this->createResponse($code, [
+            'id'      => (int) $id,
+            'jobdata' => $responseData,
+        ]);
+    }
+}

--- a/src/Command/ReserveJobCommand.php
+++ b/src/Command/ReserveJobCommand.php
@@ -2,6 +2,7 @@
 
 namespace Pheanstalk\Command;
 
+use Pheanstalk\Contract\JobIdInterface;
 use Pheanstalk\Contract\ResponseInterface;
 use Pheanstalk\Contract\ResponseParserInterface;
 use Pheanstalk\Response\ArrayResponse;
@@ -14,10 +15,11 @@ use Pheanstalk\Response\ArrayResponse;
 class ReserveJobCommand extends AbstractCommand implements ResponseParserInterface
 {
     private int $job;
-    public function __construct(int $job)
+    public function __construct(JobIdInterface $job)
     {
-       $this->job = $job;
+       $this->job = $job->getId();
     }
+
     public function getCommandLine(): string
     {
         return sprintf('reserve-job %d', $this->job);

--- a/src/Command/ReserveJobCommand.php
+++ b/src/Command/ReserveJobCommand.php
@@ -5,6 +5,7 @@ namespace Pheanstalk\Command;
 use Pheanstalk\Contract\JobIdInterface;
 use Pheanstalk\Contract\ResponseInterface;
 use Pheanstalk\Contract\ResponseParserInterface;
+use Pheanstalk\Exception\JobNotFoundException;
 use Pheanstalk\Response\ArrayResponse;
 
 /**

--- a/src/Command/ReserveJobCommand.php
+++ b/src/Command/ReserveJobCommand.php
@@ -15,7 +15,7 @@ use Pheanstalk\Response\ArrayResponse;
  */
 class ReserveJobCommand extends AbstractCommand implements ResponseParserInterface
 {
-    private int $job;
+    private $job;
     public function __construct(JobIdInterface $job)
     {
        $this->job = $job->getId();

--- a/src/Contract/PheanstalkInterface.php
+++ b/src/Contract/PheanstalkInterface.php
@@ -154,6 +154,11 @@ interface PheanstalkInterface
     public function reserve(): ?Job;
 
     /**
+     * Reserves/locks a specific job, new in beanstalkd 1.12+
+     */
+    public function reserveJob(int $job): ?Job;
+
+    /**
      * Reserves/locks a ready job in a watched tube, uses the 'reserve-with-timeout' instead of 'reserve'.
      *
      * A timeout value of 0 will cause the server to immediately return either a

--- a/src/Contract/PheanstalkInterface.php
+++ b/src/Contract/PheanstalkInterface.php
@@ -155,8 +155,10 @@ interface PheanstalkInterface
 
     /**
      * Reserves/locks a specific job, new in beanstalkd 1.12+
+     *
+     * @param JobIdInterface $job
      */
-    public function reserveJob(int $job): ?Job;
+    public function reserveJob(JobIdInterface $job): ?Job;
 
     /**
      * Reserves/locks a ready job in a watched tube, uses the 'reserve-with-timeout' instead of 'reserve'.

--- a/src/Contract/PheanstalkInterface.php
+++ b/src/Contract/PheanstalkInterface.php
@@ -158,7 +158,7 @@ interface PheanstalkInterface
      *
      * @param JobIdInterface $job
      */
-    public function reserveJob(JobIdInterface $job): ?Job;
+    public function reserveJob(JobIdInterface $job): Job;
 
     /**
      * Reserves/locks a ready job in a watched tube, uses the 'reserve-with-timeout' instead of 'reserve'.

--- a/src/Pheanstalk.php
+++ b/src/Pheanstalk.php
@@ -261,7 +261,7 @@ class Pheanstalk implements PheanstalkInterface
     /**
      * {@inheritdoc}
      */
-    public function reserveJob(int $job): ?Job
+    public function reserveJob(JobIdInterface $job): ?Job
     {
         try {
             $response = $this->dispatch(

--- a/src/Pheanstalk.php
+++ b/src/Pheanstalk.php
@@ -272,7 +272,7 @@ class Pheanstalk implements PheanstalkInterface
             throw new Exception\ServerUnknownCommandException();
         }
 
-        if ($response->getResponseName === ResponseInterface::RESPONSE_BAD_FORMAT) {
+        if ($response->getResponseName() === ResponseInterface::RESPONSE_BAD_FORMAT) {
             throw new Exception\ServerUnknownCommandException();
         }
 

--- a/src/Pheanstalk.php
+++ b/src/Pheanstalk.php
@@ -261,6 +261,26 @@ class Pheanstalk implements PheanstalkInterface
     /**
      * {@inheritdoc}
      */
+    public function reserveJob(int $job): ?Job
+    {
+        try {
+            $response = $this->dispatch(
+                new Command\ReserveJobCommand($job)
+            );
+        } catch (Exception\ServerBadFormatException $e) {
+            return null;
+        }
+
+        if ($response->getResponseName === ResponseInterface::RESPONSE_BAD_FORMAT) {
+            return null;
+        }
+
+        return new Job($response['id'], $response['jobdata']);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function reserveWithTimeout(int $timeout): ?Job
     {
         $response = $this->dispatch(

--- a/src/Pheanstalk.php
+++ b/src/Pheanstalk.php
@@ -261,14 +261,15 @@ class Pheanstalk implements PheanstalkInterface
     /**
      * {@inheritdoc}
      */
-    public function reserveJob(JobIdInterface $job): ?Job
+    public function reserveJob(JobIdInterface $job): Job
     {
+        // New in 1.12, beanstalkd returns BadFormat instead of UnknownCommand
         try {
             $response = $this->dispatch(
                 new Command\ReserveJobCommand($job)
             );
         } catch (Exception\ServerBadFormatException $e) {
-            return null;
+            throw new Exception\ServerUnknownCommandException();
         }
 
         if ($response->getResponseName === ResponseInterface::RESPONSE_BAD_FORMAT) {

--- a/src/Pheanstalk.php
+++ b/src/Pheanstalk.php
@@ -273,7 +273,7 @@ class Pheanstalk implements PheanstalkInterface
         }
 
         if ($response->getResponseName === ResponseInterface::RESPONSE_BAD_FORMAT) {
-            return null;
+            throw new Exception\ServerUnknownCommandException();
         }
 
         return new Job($response['id'], $response['jobdata']);

--- a/tests/Pheanstalk/CommandTest.php
+++ b/tests/Pheanstalk/CommandTest.php
@@ -190,6 +190,27 @@ class CommandTest extends TestCase
         );
     }
 
+    public function testReserveJob()
+    {
+        $job = new JobId(4);
+        $command = new Command\ReserveJobCommand($job);
+        $this->assertCommandLine($command, 'reserve-job 4');
+
+        $this->assertResponse(
+            $command->getResponseParser()->parseResponse('RESERVED 5 9', 'test data'),
+            ResponseInterface::RESPONSE_RESERVED,
+            ['id' => 5, 'jobdata' => 'test data']
+        );
+    }
+
+    public function testReserveJobNotFound()
+    {
+        $job = new JobId(5);
+        $command = new Command\ReserveJobCommand($job);
+        $this->expectException(Exception::class);
+        $command->getResponseParser()->parseResponse(ResponseInterface::RESPONSE_NOT_FOUND, null);
+    }
+
     public function testReserveDeadline()
     {
         $this->expectException(DeadlineSoonException::class);


### PR DESCRIPTION
Before 1.12, we'll return null if this isn't supported.

Fixes #221 