### PR TITLE
Refactor parsers

### DIFF
--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pheanstalk\Command;
 
 use Pheanstalk\Contract\CommandInterface;
+use Pheanstalk\Contract\ResponseInterface;
 use Pheanstalk\Contract\ResponseParserInterface;
 use Pheanstalk\Exception\CommandException;
 use Pheanstalk\Response\ArrayResponse;
@@ -40,7 +41,7 @@ abstract class AbstractCommand implements CommandInterface
     /**
      * Creates a Response for the given data.
      */
-    protected function createResponse(string $name, array $data = []): ArrayResponse
+    protected function createResponse(string $name, array $data = []): ResponseInterface
     {
         return new ArrayResponse($name, $data);
     }

--- a/src/Command/BuryCommand.php
+++ b/src/Command/BuryCommand.php
@@ -33,7 +33,7 @@ class BuryCommand extends JobCommand implements ResponseParserInterface
         );
     }
 
-    public function parseResponse(string $responseLine, ?string $responseData): ArrayResponse
+    public function parseResponse(\Pheanstalk\ResponseLine $responseLine, ?string $responseData): \Pheanstalk\Contract\ResponseInterface
     {
         if ($responseLine == ResponseInterface::RESPONSE_NOT_FOUND) {
             throw new Exception\JobNotFoundException(sprintf(

--- a/src/Command/DeleteCommand.php
+++ b/src/Command/DeleteCommand.php
@@ -20,7 +20,7 @@ class DeleteCommand extends JobCommand implements ResponseParserInterface
         return 'delete ' . $this->jobId;
     }
 
-    public function parseResponse(string $responseLine, ?string $responseData): ArrayResponse
+    public function parseResponse(\Pheanstalk\ResponseLine $responseLine, ?string $responseData): \Pheanstalk\Contract\ResponseInterface
     {
         if ($responseLine == ResponseInterface::RESPONSE_NOT_FOUND) {
             throw new Exception\JobNotFoundException(sprintf(

--- a/src/Command/KickCommand.php
+++ b/src/Command/KickCommand.php
@@ -34,7 +34,7 @@ class KickCommand extends AbstractCommand implements ResponseParserInterface
     /* (non-phpdoc)
      * @see ResponseParser::parseResponse()
      */
-    public function parseResponse(string $responseLine, ?string $responseData): ArrayResponse
+    public function parseResponse(\Pheanstalk\ResponseLine $responseLine, ?string $responseData): \Pheanstalk\Contract\ResponseInterface
     {
         list($code, $count) = explode(' ', $responseLine);
 

--- a/src/Command/KickJobCommand.php
+++ b/src/Command/KickJobCommand.php
@@ -29,7 +29,7 @@ class KickJobCommand extends JobCommand implements ResponseParserInterface
     /* (non-phpdoc)
      * @see ResponseParser::parseResponse()
      */
-    public function parseResponse(string $responseLine, ?string $responseData): ArrayResponse
+    public function parseResponse(\Pheanstalk\ResponseLine $responseLine, ?string $responseData): \Pheanstalk\Contract\ResponseInterface
     {
         if ($responseLine == ResponseInterface::RESPONSE_NOT_FOUND) {
             throw new Exception\JobNotFoundException(sprintf(

--- a/src/Command/ListTubeUsedCommand.php
+++ b/src/Command/ListTubeUsedCommand.php
@@ -19,7 +19,7 @@ class ListTubeUsedCommand extends AbstractCommand implements ResponseParserInter
         return 'list-tube-used';
     }
 
-    public function parseResponse(string $responseLine, ?string $responseData): ArrayResponse
+    public function parseResponse(\Pheanstalk\ResponseLine $responseLine, ?string $responseData): \Pheanstalk\Contract\ResponseInterface
     {
         return $this->createResponse('USING', [
             'tube' => preg_replace('#^USING (.+)$#', '$1', $responseLine),

--- a/src/Command/PauseTubeCommand.php
+++ b/src/Command/PauseTubeCommand.php
@@ -8,6 +8,7 @@ use Pheanstalk\Contract\ResponseInterface;
 use Pheanstalk\Contract\ResponseParserInterface;
 use Pheanstalk\Exception;
 use Pheanstalk\Response\ArrayResponse;
+use Pheanstalk\ResponseLine;
 
 /**
  * The 'pause-tube' command.
@@ -40,18 +41,15 @@ class PauseTubeCommand extends TubeCommand implements ResponseParserInterface
         );
     }
 
-    public function parseResponse(string $responseLine, ?string $responseData): ArrayResponse
+    public function parseResponse(ResponseLine $responseLine, ?string $responseData): ResponseInterface
     {
-        if ($responseLine == ResponseInterface::RESPONSE_NOT_FOUND) {
-            throw new Exception\ServerException(sprintf(
+        return match ($responseLine->getName()) {
+            ResponseInterface::RESPONSE_NOT_FOUND => throw new Exception\ServerException(sprintf(
                 '%s: tube %s does not exist.',
-                $responseLine,
+                $responseLine->getName(),
                 $this->tube
-            ));
-        } elseif ($responseLine == ResponseInterface::RESPONSE_PAUSED) {
-            return $this->createResponse(ResponseInterface::RESPONSE_PAUSED);
-        } else {
-            throw new Exception('Unhandled response: "' . $responseLine . '"');
-        }
+            )),
+            ResponseInterface::RESPONSE_PAUSED => $this->createResponse($responseLine->getName())
+        };
     }
 }

--- a/src/Command/PeekJobCommand.php
+++ b/src/Command/PeekJobCommand.php
@@ -21,7 +21,7 @@ class PeekJobCommand extends JobCommand implements ResponseParserInterface
         return sprintf('peek %u', $this->jobId);
     }
 
-    public function parseResponse(string $responseLine, ?string $responseData): ArrayResponse
+    public function parseResponse(\Pheanstalk\ResponseLine $responseLine, ?string $responseData): \Pheanstalk\Contract\ResponseInterface
     {
         if ($responseLine == ResponseInterface::RESPONSE_NOT_FOUND) {
             $message = sprintf(

--- a/src/Command/ReleaseCommand.php
+++ b/src/Command/ReleaseCommand.php
@@ -9,6 +9,7 @@ use Pheanstalk\Contract\ResponseInterface;
 use Pheanstalk\Contract\ResponseParserInterface;
 use Pheanstalk\Exception;
 use Pheanstalk\Response\ArrayResponse;
+use Pheanstalk\ResponseLine;
 
 /**
  * The 'release' command.
@@ -40,9 +41,9 @@ class ReleaseCommand extends JobCommand implements ResponseParserInterface
         );
     }
 
-    public function parseResponse(string $responseLine, ?string $responseData): ArrayResponse
+    public function parseResponse(ResponseLine $responseLine, ?string $responseData): \Pheanstalk\Contract\ResponseInterface
     {
-        if ($responseLine == ResponseInterface::RESPONSE_BURIED) {
+        if ($responseLine->getName() === ResponseInterface::RESPONSE_BURIED) {
             throw new Exception\ServerOutOfMemoryException(sprintf(
                 'Job %u %s: out of memory trying to grow data structure',
                 $this->jobId,
@@ -50,7 +51,7 @@ class ReleaseCommand extends JobCommand implements ResponseParserInterface
             ));
         }
 
-        if ($responseLine == ResponseInterface::RESPONSE_NOT_FOUND) {
+        if ($responseLine->getName() === ResponseInterface::RESPONSE_NOT_FOUND) {
             throw new Exception\JobNotFoundException(sprintf(
                 'Job %u %s: does not exist or is not reserved by client',
                 $this->jobId,
@@ -58,6 +59,6 @@ class ReleaseCommand extends JobCommand implements ResponseParserInterface
             ));
         }
 
-        return $this->createResponse($responseLine);
+        return $this->createResponse($responseLine->getName());
     }
 }

--- a/src/Command/ReserveCommand.php
+++ b/src/Command/ReserveCommand.php
@@ -21,7 +21,7 @@ class ReserveCommand extends AbstractCommand implements ResponseParserInterface
         return 'reserve';
     }
 
-    public function parseResponse(string $responseLine, ?string $responseData): ArrayResponse
+    public function parseResponse(\Pheanstalk\ResponseLine $responseLine, ?string $responseData): \Pheanstalk\Contract\ResponseInterface
     {
         if ($responseLine === ResponseInterface::RESPONSE_DEADLINE_SOON) {
             throw new DeadlineSoonException();

--- a/src/Command/ReserveJobCommand.php
+++ b/src/Command/ReserveJobCommand.php
@@ -9,6 +9,7 @@ use Pheanstalk\Contract\ResponseInterface;
 use Pheanstalk\Contract\ResponseParserInterface;
 use Pheanstalk\Exception\JobNotFoundException;
 use Pheanstalk\Response\ArrayResponse;
+use Pheanstalk\ResponseLine;
 
 /**
  * The 'reserve-job' command.
@@ -28,15 +29,14 @@ class ReserveJobCommand extends AbstractCommand implements ResponseParserInterfa
         return sprintf('reserve-job %d', $this->job);
     }
 
-    public function parseResponse(string $responseLine, ?string $responseData): ArrayResponse
+    public function parseResponse(ResponseLine $responseLine, ?string $responseData): ResponseInterface
     {
-        if ($responseLine === ResponseInterface::RESPONSE_NOT_FOUND) {
+        if ($responseLine->getName() === ResponseInterface::RESPONSE_NOT_FOUND) {
             throw new JobNotFoundException();
         }
 
-        list($code, $id) = explode(' ', $responseLine);
-        return $this->createResponse($code, [
-            'id'      => (int) $id,
+        return $this->createResponse($responseLine->getName(), [
+            'id'      => (int) $responseLine->getArguments()[0],
             'jobdata' => $responseData,
         ]);
     }

--- a/src/Command/ReserveWithTimeoutCommand.php
+++ b/src/Command/ReserveWithTimeoutCommand.php
@@ -32,7 +32,7 @@ class ReserveWithTimeoutCommand extends AbstractCommand implements ResponseParse
         return sprintf('reserve-with-timeout %s', $this->timeout);
     }
 
-    public function parseResponse(string $responseLine, ?string $responseData): ArrayResponse
+    public function parseResponse(\Pheanstalk\ResponseLine $responseLine, ?string $responseData): \Pheanstalk\Contract\ResponseInterface
     {
         if (
             $responseLine === ResponseInterface::RESPONSE_DEADLINE_SOON

--- a/src/Command/TouchCommand.php
+++ b/src/Command/TouchCommand.php
@@ -24,7 +24,7 @@ class TouchCommand extends JobCommand implements ResponseParserInterface
         return sprintf('touch %u', $this->jobId);
     }
 
-    public function parseResponse(string $responseLine, ?string $responseData): ArrayResponse
+    public function parseResponse(\Pheanstalk\ResponseLine $responseLine, ?string $responseData): \Pheanstalk\Contract\ResponseInterface
     {
         if ($responseLine == ResponseInterface::RESPONSE_NOT_FOUND) {
             throw new Exception\JobNotFoundException(sprintf(

--- a/src/Command/UseCommand.php
+++ b/src/Command/UseCommand.php
@@ -21,10 +21,10 @@ class UseCommand extends TubeCommand implements ResponseParserInterface
         return 'use ' . $this->tube;
     }
 
-    public function parseResponse(string $responseLine, ?string $responseData): ArrayResponse
+    public function parseResponse(\Pheanstalk\ResponseLine $responseLine, ?string $responseData): \Pheanstalk\Contract\ResponseInterface
     {
-        return $this->createResponse('USING', [
-            'tube' => preg_replace('#^USING (.+)$#', '$1', $responseLine),
+        return $this->createResponse($responseLine->getName(), [
+            'tube' => $responseLine->getArguments()[0]
         ]);
     }
 }

--- a/src/Command/WatchCommand.php
+++ b/src/Command/WatchCommand.php
@@ -18,10 +18,10 @@ class WatchCommand extends TubeCommand implements ResponseParserInterface
         return 'watch ' . $this->tube;
     }
 
-    public function parseResponse(string $responseLine, ?string $responseData): ArrayResponse
+    public function parseResponse(\Pheanstalk\ResponseLine $responseLine, ?string $responseData): \Pheanstalk\Contract\ResponseInterface
     {
-        return $this->createResponse('WATCHING', [
-            'count' => preg_replace('#^WATCHING (.+)$#', '$1', $responseLine),
+        return $this->createResponse($responseLine->getName(), [
+            'count' => $responseLine->getArguments()[0],
         ]);
     }
 }

--- a/src/Contract/ResponseParserInterface.php
+++ b/src/Contract/ResponseParserInterface.php
@@ -13,10 +13,10 @@ interface ResponseParserInterface
 {
     /**
      * Parses raw response data into a Response object.
-     *
-     * @param string $responseLine Without trailing CRLF
-     * @param string $responseData (null if no data)
-     * @return ArrayResponse
+     * @param \Pheanstalk\ResponseLine $responseLine Without trailing CRLF
+     * @param string|null $responseData (null if no data)
+     * @return ResponseInterface
+     * @throws \Throwable in case the line could not be parsed
      */
-    public function parseResponse(string $responseLine, ?string $responseData): ArrayResponse;
+    public function parseResponse(\Pheanstalk\ResponseLine $responseLine, ?string $responseData): ResponseInterface;
 }

--- a/src/ResponseLine.php
+++ b/src/ResponseLine.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types=1);
+
+namespace Pheanstalk;
+
+
+use Pheanstalk\Contract\ResponseInterface;
+use Pheanstalk\Exception\ServerBadFormatException;
+use Pheanstalk\Exception\ServerDrainingException;
+use Pheanstalk\Exception\ServerInternalErrorException;
+use Pheanstalk\Exception\ServerOutOfMemoryException;
+use Pheanstalk\Exception\ServerUnknownCommandException;
+
+class ResponseLine
+{
+    private string $name;
+    private array $arguments;
+    private int $dataLength = 0;
+
+    private static array $errorResponses = [
+        ResponseInterface::RESPONSE_OUT_OF_MEMORY   => ServerOutOfMemoryException::class,
+        ResponseInterface::RESPONSE_INTERNAL_ERROR  => ServerInternalErrorException::class,
+        ResponseInterface::RESPONSE_DRAINING        => ServerDrainingException::class,
+        ResponseInterface::RESPONSE_BAD_FORMAT      => ServerBadFormatException::class,
+        ResponseInterface::RESPONSE_UNKNOWN_COMMAND => ServerUnknownCommandException::class,
+    ];
+
+    private static array $dataResponses = [
+        ResponseInterface::RESPONSE_RESERVED,
+        ResponseInterface::RESPONSE_FOUND,
+        ResponseInterface::RESPONSE_OK,
+    ];
+
+    public function getArguments(): array
+    {
+        return $this->arguments;
+    }
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function __construct(string $name, array $arguments = [])
+    {
+        if (isset(self::$errorResponses[$name])) {
+            throw new self::$errorResponses[$name];
+            // Todo:
+//            throw new $exceptionClass(sprintf(
+//                "%s in response to '%s'",
+//                $responseName,
+//                $command->getCommandLine()
+//            ));
+
+        }
+        $this->name = $name;
+        if (in_array($name, self::$dataResponses)) {
+            $this->dataLength = (int) array_pop($arguments);
+        }
+
+        $this->arguments = $arguments;
+    }
+
+    public function hasData(): bool
+    {
+        return $this->dataLength > 0;
+    }
+
+    public function getDataLength(): int
+    {
+        return $this->dataLength;
+    }
+
+    public static function fromString(string $line): self
+    {
+        $parts = preg_split('/\s+/', trim($line));
+
+        $result = new self(array_shift($parts));
+        $result->arguments = $parts;
+
+        return $result;
+    }
+}

--- a/src/Socket/FileSocket.php
+++ b/src/Socket/FileSocket.php
@@ -56,8 +56,8 @@ abstract class FileSocket implements SocketInterface
     {
         $this->checkClosed();
         $buffer = '';
-        while (mb_strlen($buffer, '8BIT') < $length) {
-            $result = fread($this->socket, $length - mb_strlen($buffer, '8BIT'));
+        while (mb_strlen($buffer, '8bit') < $length) {
+            $result = fread($this->socket, $length - mb_strlen($buffer, '8bit'));
             if ($result === false) {
                 $this->throwException();
             }

--- a/src/Socket/SocketSocket.php
+++ b/src/Socket/SocketSocket.php
@@ -24,8 +24,8 @@ class SocketSocket implements SocketInterface
             throw new \Exception('Sockets extension not found');
         }
 
-        $socket = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
-        if ($socket === false) {
+        $this->socket = @socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+        if ($this->socket === false) {
             $this->throwException();
         }
         $this->socket = $socket;
@@ -68,7 +68,7 @@ class SocketSocket implements SocketInterface
     {
         $this->checkClosed();
         while (!empty($data)) {
-            $written = socket_write($this->socket, $data);
+            $written = @socket_write($this->socket, $data);
             if ($written === false) {
                 $this->throwException();
             }
@@ -99,8 +99,8 @@ class SocketSocket implements SocketInterface
         $this->checkClosed();
 
         $buffer = '';
-        while (mb_strlen($buffer, '8BIT') < $length) {
-            $result = socket_read($this->socket, $length - mb_strlen($buffer, '8BIT'));
+        while (mb_strlen($buffer, '8bit') < $length) {
+            $result = @socket_read($this->socket, $length - mb_strlen($buffer, '8bit'));
             if ($result === false) {
                 $this->throwException();
             }
@@ -117,7 +117,7 @@ class SocketSocket implements SocketInterface
         $buffer = '';
         // Reading stops at \r or \n. In case it stopped at \r we must continue reading.
         while (substr($buffer, -1, 1) !== "\n") {
-            $result = socket_read($this->socket, 1024, PHP_NORMAL_READ);
+            $result = @socket_read($this->socket, 1024, PHP_NORMAL_READ);
             if ($result === false) {
                 $this->throwException();
             }

--- a/src/YamlResponseParser.php
+++ b/src/YamlResponseParser.php
@@ -33,19 +33,16 @@ class YamlResponseParser implements ResponseParserInterface
         $this->mode = $mode;
     }
 
-    public function parseResponse(string $responseLine, ?string $responseData): ArrayResponse
+    public function parseResponse(ResponseLine $responseLine, ?string $responseData): ResponseInterface
     {
-        if ($responseLine === ResponseInterface::RESPONSE_NOT_FOUND) {
-            throw new Exception\ServerException(sprintf(
-                'Server reported %s',
-                $responseLine
-            ));
+        if ($responseLine->getName() === ResponseInterface::RESPONSE_NOT_FOUND) {
+            throw new Exception\ServerException('Not found');
         }
 
-        if (!preg_match('#^OK \d+$#', $responseLine)) {
+        if ($responseLine->getName() !== ResponseInterface::RESPONSE_OK) {
             throw new Exception\ServerException(sprintf(
                 'Unhandled response: "%s"',
-                $responseLine
+                $responseLine->getName()
             ));
         }
 

--- a/tests/Pheanstalk/CommandTest.php
+++ b/tests/Pheanstalk/CommandTest.php
@@ -31,6 +31,7 @@ use Pheanstalk\Contract\ResponseInterface;
 use Pheanstalk\Exception;
 use Pheanstalk\Exception\DeadlineSoonException;
 use Pheanstalk\JobId;
+use Pheanstalk\ResponseLine;
 
 /**
  * Tests for Command implementations.
@@ -45,7 +46,7 @@ class CommandTest extends BaseTestCase
         $this->assertCommandLine($command, 'bury 5 2');
 
         $this->assertResponse(
-            $command->getResponseParser()->parseResponse('BURIED', null),
+            $command->getResponseParser()->parseResponse(ResponseLine::fromString('BURIED'), null),
             ResponseInterface::RESPONSE_BURIED
         );
     }
@@ -56,7 +57,7 @@ class CommandTest extends BaseTestCase
         $this->assertCommandLine($command, 'delete 5');
 
         $this->assertResponse(
-            $command->getResponseParser()->parseResponse('DELETED', null),
+            $command->getResponseParser()->parseResponse(ResponseLine::fromString('DELETED'), null),
             ResponseInterface::RESPONSE_DELETED
         );
     }
@@ -67,7 +68,7 @@ class CommandTest extends BaseTestCase
         $this->assertCommandLine($command, 'ignore tube1');
 
         $this->assertResponse(
-            $command->getResponseParser()->parseResponse('WATCHING 2', null),
+            $command->getResponseParser()->parseResponse(ResponseLine::fromString('WATCHING 2'), null),
             ResponseInterface::RESPONSE_WATCHING,
             ['count' => 2]
         );
@@ -77,49 +78,49 @@ class CommandTest extends BaseTestCase
     {
         $command = new IgnoreCommand('tube1');
         $this->expectException(Exception::class);
-        $command->getResponseParser()->parseResponse(__FUNCTION__, null);
+        $command->getResponseParser()->parseResponse(ResponseLine::fromString(__FUNCTION__), null);
     }
 
     public function testPauseTubeBadResponse()
     {
         $command = new PauseTubeCommand('tube1', 1);
-        $this->expectException(Exception::class);
-        $command->getResponseParser()->parseResponse(__FUNCTION__, null);
+        $this->expectError();
+        $command->getResponseParser()->parseResponse(ResponseLine::fromString(__FUNCTION__), null);
     }
 
     public function testBuryBadResponse()
     {
         $command = new BuryCommand(new JobId(15), 1);
         $this->expectException(Exception::class);
-        $command->getResponseParser()->parseResponse(__FUNCTION__, null);
+        $command->getResponseParser()->parseResponse(ResponseLine::fromString(__FUNCTION__), null);
     }
 
     public function testPeekBadResponse()
     {
         $command = new PeekCommand(PeekCommand::TYPE_BURIED);
         $this->expectException(Exception::class);
-        $command->getResponseParser()->parseResponse(__FUNCTION__, null);
+        $command->getResponseParser()->parseResponse(ResponseLine::fromString(__FUNCTION__), null);
     }
 
     public function testPeekJobBadResponse()
     {
         $command = new PeekJobCommand(new JobId(15));
         $this->expectException(Exception::class);
-        $command->getResponseParser()->parseResponse(__FUNCTION__, null);
+        $command->getResponseParser()->parseResponse(ResponseLine::fromString(__FUNCTION__), null);
     }
 
     public function testKickJobBadResponse()
     {
         $command = new KickJobCommand(new JobId(15));
         $this->expectException(Exception::class);
-        $command->getResponseParser()->parseResponse(__FUNCTION__, null);
+        $command->getResponseParser()->parseResponse(ResponseLine::fromString(__FUNCTION__), null);
     }
 
     public function testKickJobNotFound()
     {
         $command = new KickJobCommand(new JobId(15));
         $this->expectException(Exception::class);
-        $command->getResponseParser()->parseResponse(ResponseInterface::RESPONSE_NOT_FOUND, null);
+        $command->getResponseParser()->parseResponse(ResponseLine::fromString(ResponseInterface::RESPONSE_NOT_FOUND), null);
     }
 
     public function testKick()
@@ -128,7 +129,7 @@ class CommandTest extends BaseTestCase
         $this->assertCommandLine($command, 'kick 5');
 
         $this->assertResponse(
-            $command->getResponseParser()->parseResponse('KICKED 2', null),
+            $command->getResponseParser()->parseResponse(ResponseLine::fromString('KICKED 2'), null),
             ResponseInterface::RESPONSE_KICKED,
             ['kicked' => 2]
         );
@@ -140,7 +141,7 @@ class CommandTest extends BaseTestCase
         $this->assertCommandLine($command, 'kick-job 5');
 
         $this->assertResponse(
-            $command->getResponseParser()->parseResponse('KICKED', null),
+            $command->getResponseParser()->parseResponse(ResponseLine::fromString('KICKED'), null),
             ResponseInterface::RESPONSE_KICKED
         );
     }
@@ -151,7 +152,7 @@ class CommandTest extends BaseTestCase
         $this->assertCommandLine($command, 'list-tubes-watched');
 
         $this->assertResponse(
-            $command->getResponseParser()->parseResponse('OK 16', "---\n- one\n- two\n"),
+            $command->getResponseParser()->parseResponse(ResponseLine::fromString('OK 16'), "---\n- one\n- two\n"),
             ResponseInterface::RESPONSE_OK,
             ['one', 'two']
         );
@@ -163,7 +164,7 @@ class CommandTest extends BaseTestCase
         $this->assertCommandLine($command, 'list-tube-used');
 
         $this->assertResponse(
-            $command->getResponseParser()->parseResponse('USING default', null),
+            $command->getResponseParser()->parseResponse(ResponseLine::fromString('USING default'), null),
             ResponseInterface::RESPONSE_USING,
             ['tube' => 'default']
         );
@@ -176,7 +177,7 @@ class CommandTest extends BaseTestCase
         $this->assertEquals('data', $command->getData());
 
         $this->assertResponse(
-            $command->getResponseParser()->parseResponse('INSERTED 4', null),
+            $command->getResponseParser()->parseResponse(ResponseLine::fromString('INSERTED 4'), null),
             ResponseInterface::RESPONSE_INSERTED,
             ['id' => '4']
         );
@@ -186,7 +187,7 @@ class CommandTest extends BaseTestCase
     {
         $command = new PutCommand('data', 5, 6, 7);
         $this->expectException(Exception::class);
-        $command->getResponseParser()->parseResponse('BURIED 4', null);
+        $command->getResponseParser()->parseResponse(ResponseLine::fromString('BURIED 4'), null);
     }
 
     public function testRelease()
@@ -196,7 +197,7 @@ class CommandTest extends BaseTestCase
         $this->assertCommandLine($command, 'release 3 1 0');
 
         $this->assertResponse(
-            $command->getResponseParser()->parseResponse('RELEASED', null),
+            $command->getResponseParser()->parseResponse(ResponseLine::fromString('RELEASED'), null),
             ResponseInterface::RESPONSE_RELEASED
         );
     }
@@ -207,7 +208,7 @@ class CommandTest extends BaseTestCase
         $this->assertCommandLine($command, 'reserve');
 
         $this->assertResponse(
-            $command->getResponseParser()->parseResponse('RESERVED 5 9', 'test data'),
+            $command->getResponseParser()->parseResponse(ResponseLine::fromString('RESERVED 5 9'), 'test data'),
             ResponseInterface::RESPONSE_RESERVED,
             ['id' => 5, 'jobdata' => 'test data']
         );
@@ -220,7 +221,7 @@ class CommandTest extends BaseTestCase
         $this->assertCommandLine($command, 'reserve-job 4');
 
         $this->assertResponse(
-            $command->getResponseParser()->parseResponse('RESERVED 5 9', 'test data'),
+            $command->getResponseParser()->parseResponse(ResponseLine::fromString('RESERVED 5 9'), 'test data'),
             ResponseInterface::RESPONSE_RESERVED,
             ['id' => 5, 'jobdata' => 'test data']
         );
@@ -231,7 +232,7 @@ class CommandTest extends BaseTestCase
         $job = new JobId(5);
         $command = new ReserveJobCommand($job);
         $this->expectException(Exception::class);
-        $command->getResponseParser()->parseResponse(ResponseInterface::RESPONSE_NOT_FOUND, null);
+        $command->getResponseParser()->parseResponse(ResponseLine::fromString(ResponseInterface::RESPONSE_NOT_FOUND), null);
     }
 
     public function testReserveDeadline()
@@ -239,7 +240,7 @@ class CommandTest extends BaseTestCase
         $this->expectException(DeadlineSoonException::class);
         $command = new ReserveCommand();
 
-        $command->getResponseParser()->parseResponse('DEADLINE_SOON', null);
+        $command->getResponseParser()->parseResponse(ResponseLine::fromString('DEADLINE_SOON'), null);
     }
 
     public function testUse()
@@ -248,7 +249,7 @@ class CommandTest extends BaseTestCase
         $this->assertCommandLine($command, 'use tube5');
 
         $this->assertResponse(
-            $command->getResponseParser()->parseResponse('USING tube5', null),
+            $command->getResponseParser()->parseResponse(ResponseLine::fromString('USING tube5'), null),
             ResponseInterface::RESPONSE_USING,
             ['tube' => 'tube5']
         );
@@ -260,7 +261,7 @@ class CommandTest extends BaseTestCase
         $this->assertCommandLine($command, 'watch tube6');
 
         $this->assertResponse(
-            $command->getResponseParser()->parseResponse('WATCHING 3', null),
+            $command->getResponseParser()->parseResponse(ResponseLine::fromString('WATCHING 3'), null),
             ResponseInterface::RESPONSE_WATCHING,
             ['count' => '3']
         );
@@ -272,7 +273,7 @@ class CommandTest extends BaseTestCase
         $this->assertCommandLine($command, 'reserve-with-timeout 10');
 
         $this->assertResponse(
-            $command->getResponseParser()->parseResponse('TIMED_OUT', null),
+            $command->getResponseParser()->parseResponse(ResponseLine::fromString('TIMED_OUT'), null),
             ResponseInterface::RESPONSE_TIMED_OUT
         );
     }
@@ -283,7 +284,7 @@ class CommandTest extends BaseTestCase
         $this->assertCommandLine($command, 'touch 5');
 
         $this->assertResponse(
-            $command->getResponseParser()->parseResponse('TOUCHED', null),
+            $command->getResponseParser()->parseResponse(ResponseLine::fromString('TOUCHED'), null),
             ResponseInterface::RESPONSE_TOUCHED
         );
     }
@@ -294,7 +295,7 @@ class CommandTest extends BaseTestCase
         $this->assertCommandLine($command, 'list-tubes');
 
         $this->assertResponse(
-            $command->getResponseParser()->parseResponse('OK 16', "---\n- one\n- two\n"),
+            $command->getResponseParser()->parseResponse(ResponseLine::fromString('OK 16'), "---\n- one\n- two\n"),
             ResponseInterface::RESPONSE_OK,
             ['one', 'two']
         );
@@ -306,7 +307,7 @@ class CommandTest extends BaseTestCase
         $this->assertCommandLine($command, 'peek 5');
 
         $this->assertResponse(
-            $command->getResponseParser()->parseResponse('FOUND 5 9', 'test data'),
+            $command->getResponseParser()->parseResponse(ResponseLine::fromString('FOUND 5 9'), 'test data'),
             ResponseInterface::RESPONSE_FOUND,
             ['id' => 5, 'jobdata' => 'test data']
         );
@@ -338,7 +339,7 @@ class CommandTest extends BaseTestCase
         $data = "---\nid: 8\ntube: test\nstate: delayed\n";
 
         $this->assertResponse(
-            $command->getResponseParser()->parseResponse('OK ' . strlen($data), $data),
+            $command->getResponseParser()->parseResponse(ResponseLine::fromString('OK ' . strlen($data)), $data),
             ResponseInterface::RESPONSE_OK,
             ['id' => '8', 'tube' => 'test', 'state' => 'delayed']
         );
@@ -352,7 +353,7 @@ class CommandTest extends BaseTestCase
         $data = "---\nname: test\ncurrent-jobs-ready: 5\n";
 
         $this->assertResponse(
-            $command->getResponseParser()->parseResponse('OK ' . strlen($data), $data),
+            $command->getResponseParser()->parseResponse(ResponseLine::fromString('OK ' . strlen($data)), $data),
             ResponseInterface::RESPONSE_OK,
             ['name' => 'test', 'current-jobs-ready' => '5']
         );
@@ -366,7 +367,7 @@ class CommandTest extends BaseTestCase
         $data = "---\npid: 123\nversion: 1.3\n";
 
         $this->assertResponse(
-            $command->getResponseParser()->parseResponse('OK ' . strlen($data), $data),
+            $command->getResponseParser()->parseResponse(ResponseLine::fromString('OK ' . strlen($data)), $data),
             ResponseInterface::RESPONSE_OK,
             ['pid' => '123', 'version' => '1.3']
         );
@@ -377,7 +378,7 @@ class CommandTest extends BaseTestCase
         $command = new PauseTubeCommand('testtube7', 10);
         $this->assertCommandLine($command, 'pause-tube testtube7 10');
         $this->assertResponse(
-            $command->getResponseParser()->parseResponse('PAUSED', null),
+            $command->getResponseParser()->parseResponse(ResponseLine::fromString('PAUSED'), null),
             ResponseInterface::RESPONSE_PAUSED
         );
     }
@@ -390,7 +391,7 @@ class CommandTest extends BaseTestCase
         $command = new StatsCommand();
 
         $this->assertResponse(
-            $command->getResponseParser()->parseResponse('OK ' . strlen($data), $data),
+            $command->getResponseParser()->parseResponse(ResponseLine::fromString('OK ' . strlen($data)), $data),
             ResponseInterface::RESPONSE_OK,
             ['pid' => '123', 'version' => '', 'key' => 'value']
         );

--- a/tests/Pheanstalk/ResponseLineTest.php
+++ b/tests/Pheanstalk/ResponseLineTest.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace Pheanstalk\Tests;
+
+use Pheanstalk\ResponseLine;
+
+/**
+ * @covers \Pheanstalk\ResponseLine
+ */
+class ResponseLineTest extends BaseTestCase
+{
+    public function testFactory()
+    {
+        $r = ResponseLine::fromString('   RESERVED 5 123  ');
+
+    }
+}

--- a/tests/Pheanstalk/ResponseParserExceptionTest.php
+++ b/tests/Pheanstalk/ResponseParserExceptionTest.php
@@ -20,6 +20,7 @@ use Pheanstalk\Exception;
 use Pheanstalk\Exception\CommandException;
 use Pheanstalk\Exception\ServerException;
 use Pheanstalk\JobId;
+use Pheanstalk\ResponseLine;
 use Pheanstalk\YamlResponseParser;
 
 /**
@@ -134,7 +135,7 @@ class ResponseParserExceptionTest extends BaseTestCase
         string $type = Exception::class
     ) {
         $this->expectException($type);
-        $parser->parseResponse($response, null);
+        $parser->parseResponse(ResponseLine::fromString($response), null);
     }
 
     private function expectServerExceptionForResponse(ResponseParserInterface $parser, string $response)

--- a/tests/Pheanstalk/YamlResponseParserTest.php
+++ b/tests/Pheanstalk/YamlResponseParserTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pheanstalk\Tests;
 
 use Pheanstalk\Exception\ClientException;
+use Pheanstalk\ResponseLine;
 use Pheanstalk\YamlResponseParser;
 
 class YamlResponseParserTest extends BaseTestCase
@@ -13,7 +14,7 @@ class YamlResponseParserTest extends BaseTestCase
     public function testList()
     {
         $parser = new YamlResponseParser(YamlResponseParser::MODE_LIST);
-        $response = $parser->parseResponse('OK 1', "---\n- a\n- b");
+        $response = $parser->parseResponse(ResponseLine::fromString('OK 1'), "---\n- a\n- b");
         $this->assertSame(['a', 'b'], iterator_to_array($response));
     }
 
@@ -21,13 +22,13 @@ class YamlResponseParserTest extends BaseTestCase
     {
         $this->expectException(ClientException::class);
         $parser = new YamlResponseParser(YamlResponseParser::MODE_LIST);
-        $response = $parser->parseResponse('OK 1', "---\n- a\nb");
+        $response = $parser->parseResponse(ResponseLine::fromString('OK 1'), "---\n- a\nb");
     }
 
     public function testInvalidDictionary()
     {
         $this->expectException(ClientException::class);
         $parser = new YamlResponseParser(YamlResponseParser::MODE_DICT);
-        $response = $parser->parseResponse('OK 1', "---\n: b\n");
+        $response = $parser->parseResponse(ResponseLine::fromString('OK 1'), "---\n: b\n");
     }
 }


### PR DESCRIPTION
Currently knowledge of the whole protocol is in the command specific response parsers.

This is not structurally sound and leads to things like:
- Unnecessary checks for error responses in the parser
- Throwing exceptions in the parser that should be thrown in the connection instead


A parser should have 1 job: to parse a response to a command into a response object.

The flow should be roughly like this:
1. Connection gets command to dispatch
2. Connection sends command line
3. Connection reads response line, passes it to `ResponseLine::fromString()`
4. Connection checks if the response has data, `ResponseLine::hasData`, and if so reads it.
5. Connection passes the `ResponseLine` and the data, if any, to the parser. It finds this parser by inspecting the `ResponseLine`, not the `Command`
7. Parser creates a response object if it is a valid response.
8. Pheanstalk uses the response to either throw an exception, wrap it in a more user friendly data structure, or return it as is.

The reasoning behind this is that `NOT_FOUND` is a perfectly valid response from a protocol perspective and should therefore not throw exceptions in the lower levels of the library. Instead, only at the most abstract level, where we can reasonably say an exception is expected we throw exceptions.


Suggestions & discussion welcome ofcourse.