### PR TITLE
Don't log warnings from SocketSocket usage

### DIFF
--- a/src/Socket/SocketSocket.php
+++ b/src/Socket/SocketSocket.php
@@ -24,7 +24,7 @@ class SocketSocket implements SocketInterface
             throw new \Exception('Sockets extension not found');
         }
 
-        $this->socket = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+        $this->socket = @socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
         if ($this->socket === false) {
             $this->throwException();
         }
@@ -67,7 +67,7 @@ class SocketSocket implements SocketInterface
     {
         $this->checkClosed();
         while (!empty($data)) {
-            $written = socket_write($this->socket, $data);
+            $written = @socket_write($this->socket, $data);
             if ($written === false) {
                 $this->throwException();
             }
@@ -99,7 +99,7 @@ class SocketSocket implements SocketInterface
 
         $buffer = '';
         while (mb_strlen($buffer, '8bit') < $length) {
-            $result = socket_read($this->socket, $length - mb_strlen($buffer, '8bit'));
+            $result = @socket_read($this->socket, $length - mb_strlen($buffer, '8bit'));
             if ($result === false) {
                 $this->throwException();
             }
@@ -116,7 +116,7 @@ class SocketSocket implements SocketInterface
         $buffer = '';
         // Reading stops at \r or \n. In case it stopped at \r we must continue reading.
         while (substr($buffer, -1, 1) !== "\n") {
-            $result = socket_read($this->socket, 1024, PHP_NORMAL_READ);
+            $result = @socket_read($this->socket, 1024, PHP_NORMAL_READ);
             if ($result === false) {
                 $this->throwException();
             }


### PR DESCRIPTION
Return values are checked for errors, which raise an appropriate
exception.