### PR TITLE
Remove internal annotion from JobStats value object

### DIFF
--- a/src/Values/JobStats.php
+++ b/src/Values/JobStats.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Pheanstalk\Values;
 
-/**
- * @internal
- */
 final class JobStats
 {
     private const KEYS = [


### PR DESCRIPTION
JobStats shouldn't be internal, as they are used as return type for public functions. Wonder why static analyze doesn't bring this up.