### PR TITLE
fix: Change the response parsing to treat 0 as a number

### DIFF
--- a/src/Values/RawResponse.php
+++ b/src/Values/RawResponse.php
@@ -19,7 +19,7 @@ final class RawResponse
         // Cast numeric strings to integers, if possible.
         $this->argument = match (true) {
             $argument === null => null,
-            ctype_digit($argument) && !str_starts_with($argument, "0") && $argument < PHP_INT_MAX => (int)$argument,
+            ctype_digit($argument) && (!str_starts_with($argument, "0") || $argument === '0') && $argument < PHP_INT_MAX => (int)$argument,
             default => $argument
         };
     }

--- a/tests/Integration/PheanstalkTestBase.php
+++ b/tests/Integration/PheanstalkTestBase.php
@@ -385,6 +385,14 @@ abstract class PheanstalkTestBase extends TestCase
         self::assertSame(JobState::READY, $pheanstalk->statsJob($jobId)->state);
     }
 
+
+    public function testKickWillReturn0WhenNoJobsAreKilled(): void
+    {
+        $pheanstalk = $this->getPheanstalk();
+        self::assertSame(0, $pheanstalk->stats()->currentJobsBuried);
+        self::assertSame(0, $pheanstalk->kick(1));
+    }
+
     final protected function getHost(): string
     {
         if (str_contains(static::class, "Unix")) {

--- a/tests/Unit/Values/RawResponseTest.php
+++ b/tests/Unit/Values/RawResponseTest.php
@@ -18,6 +18,11 @@ final class RawResponseTest extends TestCase
         self::assertSame(123, (new RawResponse(ResponseType::DeadlineSoon, '123'))->argument);
     }
 
+    public function testTheNumberZeroIsCast(): void
+    {
+        self::assertSame(0, (new RawResponse(ResponseType::Kicked, '0'))->argument);
+    }
+
     public function testNull(): void
     {
         self::assertNull((new RawResponse(ResponseType::DeadlineSoon))->argument);


### PR DESCRIPTION
When using the library to kick jobs in a tube I noticed that when there weren't any jobs to be kicked, beanstalk would return `KICKED 0`, but the library would throw a `Pheanstalk\Exception\MalformedResponseException`.

After a bit of digging I found the part which is responsible for this in the RawResponse code. It seems that numeric strings that start with a 0 are not interpreted as a number. I wasn't able to determine why this rule exists, but I opted to leave it and just extend the rule a bit so that the value "0" is considered a number again.

The solution fixes the test cases I made (expecting "kick" to return the number 0 when no jobs were actually kicked). I'm not sure if my proposed fix is the best solution, so I'd appreciate any input.

Another solution I would see is that the fix could also be lifted up a "layer" into the `KickCommand::interpret` method. There the check could be changed from `is_int($response->argument)` to `(is_int($response->argument) || $response->argument === '0')`. I didn't choose to do that because my proposed solution is a bit more general and might improve other commands as well (ok, well only Ignore and Watch use the `is_int` check as well, but it seems that those can't return 0 since you can't ignore all tubes).

I hope my description is clear, don't hesitate to ask if it is missing some information - thank you for any feedback.