### PR TITLE
Mark parameters explicit nullable

### DIFF
--- a/src/Pheanstalk.php
+++ b/src/Pheanstalk.php
@@ -43,8 +43,8 @@ final class Pheanstalk implements PheanstalkManagerInterface, PheanstalkPublishe
     public static function create(
         string $host,
         int $port = 11300,
-        Timeout $connectTimeout = null,
-        Timeout $receiveTimeout = null
+        ?Timeout $connectTimeout = null,
+        ?Timeout $receiveTimeout = null
     ): static {
         return static::createWithFactory(new SocketFactory($host, $port, null, $connectTimeout, $receiveTimeout));
     }

--- a/src/SocketFactory.php
+++ b/src/SocketFactory.php
@@ -36,9 +36,9 @@ final class SocketFactory implements SocketFactoryInterface
         private readonly string $host,
         private readonly int $port = self::DEFAULT_PORT,
         null|SocketImplementation $implementation = null,
-        Timeout $connectTimeout = null,
-        Timeout $receiveTimeout = null,
-        Timeout $sendTimeout = null,
+        ?Timeout $connectTimeout = null,
+        ?Timeout $receiveTimeout = null,
+        ?Timeout $sendTimeout = null,
     ) {
         $this->implementation = $implementation ?? $this->detectImplementation();
 

--- a/src/StaticFactoryTrait.php
+++ b/src/StaticFactoryTrait.php
@@ -21,8 +21,8 @@ trait StaticFactoryTrait
     public static function create(
         string $host,
         int $port = 11300,
-        Timeout $connectTimeout = null,
-        Timeout $receiveTimeout = null
+        ?Timeout $connectTimeout = null,
+        ?Timeout $receiveTimeout = null
     ): self {
         return self::createWithFactory(new SocketFactory($host, $port, null, $connectTimeout, $receiveTimeout));
     }

--- a/tests/Unit/Command/BuryCommandTest.php
+++ b/tests/Unit/Command/BuryCommandTest.php
@@ -28,7 +28,7 @@ final class BuryCommandTest extends JobCommandTestBase
         return [ResponseType::NotFound, ResponseType::Buried];
     }
 
-    protected function getSubject(JobIdInterface $jobId = null): BuryCommand
+    protected function getSubject(?JobIdInterface $jobId = null): BuryCommand
     {
         return new BuryCommand($jobId ?? new JobId(5), 1);
     }

--- a/tests/Unit/Command/ConcreteJobCommandTest.php
+++ b/tests/Unit/Command/ConcreteJobCommandTest.php
@@ -23,7 +23,7 @@ final class ConcreteJobCommandTest extends JobCommandTestBase
         return [ResponseType::NotFound];
     }
 
-    protected function getSubject(JobIdInterface $jobId = null): JobCommand
+    protected function getSubject(?JobIdInterface $jobId = null): JobCommand
     {
         /** @psalm-suppress InternalClass */
         return new class($jobId ?? new JobId(5)) extends JobCommand {

--- a/tests/Unit/Command/ConcreteTubeCommandTest.php
+++ b/tests/Unit/Command/ConcreteTubeCommandTest.php
@@ -24,7 +24,7 @@ final class ConcreteTubeCommandTest extends TubeCommandTestBase
         ];
     }
 
-    protected function getSubject(TubeName $tube = null): TubeCommand
+    protected function getSubject(?TubeName $tube = null): TubeCommand
     {
         /** @psalm-suppress InternalClass */
         return new class($tube ?? new TubeName('default')) extends TubeCommand {

--- a/tests/Unit/Command/DeleteCommandTest.php
+++ b/tests/Unit/Command/DeleteCommandTest.php
@@ -27,7 +27,7 @@ final class DeleteCommandTest extends JobCommandTestBase
         return [ResponseType::NotFound, ResponseType::Deleted];
     }
 
-    protected function getSubject(JobIdInterface $jobId = null): DeleteCommand
+    protected function getSubject(?JobIdInterface $jobId = null): DeleteCommand
     {
         return new DeleteCommand($jobId ?? new JobId(5));
     }

--- a/tests/Unit/Command/IgnoreCommandTest.php
+++ b/tests/Unit/Command/IgnoreCommandTest.php
@@ -35,7 +35,7 @@ final class IgnoreCommandTest extends TubeCommandTestBase
         return [ResponseType::NotIgnored, ResponseType::Watching];
     }
 
-    protected function getSubject(TubeName $tube = null): IgnoreCommand
+    protected function getSubject(?TubeName $tube = null): IgnoreCommand
     {
         return new IgnoreCommand($tube ?? new TubeName("default"));
     }

--- a/tests/Unit/Command/JobCommandTestBase.php
+++ b/tests/Unit/Command/JobCommandTestBase.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\Assert;
 
 abstract class JobCommandTestBase extends CommandTestBase
 {
-    abstract protected function getSubject(JobIdInterface $jobId = null): JobCommand;
+    abstract protected function getSubject(?JobIdInterface $jobId = null): JobCommand;
 
     public function testInterpretNotFound(): void
     {

--- a/tests/Unit/Command/KickJobCommandTest.php
+++ b/tests/Unit/Command/KickJobCommandTest.php
@@ -27,7 +27,7 @@ final class KickJobCommandTest extends JobCommandTestBase
         return [ResponseType::NotFound, ResponseType::Kicked];
     }
 
-    protected function getSubject(JobIdInterface $jobId = null): KickJobCommand
+    protected function getSubject(?JobIdInterface $jobId = null): KickJobCommand
     {
         return new KickJobCommand($jobId ?? new JobId(5));
     }

--- a/tests/Unit/Command/PauseTubeCommandTest.php
+++ b/tests/Unit/Command/PauseTubeCommandTest.php
@@ -26,7 +26,7 @@ final class PauseTubeCommandTest extends TubeCommandTestBase
         return [ResponseType::NotFound, ResponseType::Paused];
     }
 
-    protected function getSubject(TubeName $tube = null): PauseTubeCommand
+    protected function getSubject(?TubeName $tube = null): PauseTubeCommand
     {
         return new PauseTubeCommand($tube ?? new TubeName("default"), 123);
     }

--- a/tests/Unit/Command/PeekCommandTest.php
+++ b/tests/Unit/Command/PeekCommandTest.php
@@ -48,7 +48,7 @@ final class PeekCommandTest extends CommandTestBase
         return [ResponseType::NotFound, ResponseType::Found];
     }
 
-    protected function getSubject(JobState $state = null): PeekCommand
+    protected function getSubject(?JobState $state = null): PeekCommand
     {
         return new PeekCommand($state ?? JobState::READY);
     }

--- a/tests/Unit/Command/PeekJobCommandTest.php
+++ b/tests/Unit/Command/PeekJobCommandTest.php
@@ -30,7 +30,7 @@ final class PeekJobCommandTest extends JobCommandTestBase
         return [ResponseType::NotFound, ResponseType::Found];
     }
 
-    protected function getSubject(JobIdInterface $jobId = null): PeekJobCommand
+    protected function getSubject(?JobIdInterface $jobId = null): PeekJobCommand
     {
         return new PeekJobCommand($jobId ?? new JobId(5));
     }

--- a/tests/Unit/Command/ReleaseCommandTest.php
+++ b/tests/Unit/Command/ReleaseCommandTest.php
@@ -28,7 +28,7 @@ final class ReleaseCommandTest extends JobCommandTestBase
         return [ResponseType::NotFound, ResponseType::Released];
     }
 
-    protected function getSubject(JobIdInterface $jobId = null): ReleaseCommand
+    protected function getSubject(?JobIdInterface $jobId = null): ReleaseCommand
     {
         return new ReleaseCommand($jobId ?? new JobId(5), 123, 321);
     }

--- a/tests/Unit/Command/ReserveJobCommandTest.php
+++ b/tests/Unit/Command/ReserveJobCommandTest.php
@@ -30,7 +30,7 @@ final class ReserveJobCommandTest extends JobCommandTestBase
         return [ResponseType::NotFound, ResponseType::Reserved];
     }
 
-    protected function getSubject(JobIdInterface $jobId = null): ReserveJobCommand
+    protected function getSubject(?JobIdInterface $jobId = null): ReserveJobCommand
     {
         return new ReserveJobCommand($jobId ?? new JobId(5));
     }

--- a/tests/Unit/Command/StatsJobCommandTest.php
+++ b/tests/Unit/Command/StatsJobCommandTest.php
@@ -49,7 +49,7 @@ final class StatsJobCommandTest extends JobCommandTestBase
         return [ResponseType::NotFound, ResponseType::Ok];
     }
 
-    protected function getSubject(JobIdInterface $jobId = null): StatsJobCommand
+    protected function getSubject(?JobIdInterface $jobId = null): StatsJobCommand
     {
         return new StatsJobCommand($jobId ?? new JobId(5));
     }

--- a/tests/Unit/Command/StatsTubeCommandTest.php
+++ b/tests/Unit/Command/StatsTubeCommandTest.php
@@ -61,7 +61,7 @@ final class StatsTubeCommandTest extends TubeCommandTestBase
         return [ResponseType::NotFound, ResponseType::Ok];
     }
 
-    protected function getSubject(TubeName $tube = null): StatsTubeCommand
+    protected function getSubject(?TubeName $tube = null): StatsTubeCommand
     {
         return new StatsTubeCommand($tube ?? new TubeName("default"));
     }

--- a/tests/Unit/Command/TouchCommandTest.php
+++ b/tests/Unit/Command/TouchCommandTest.php
@@ -27,7 +27,7 @@ final class TouchCommandTest extends JobCommandTestBase
         return [ResponseType::NotFound, ResponseType::Touched];
     }
 
-    protected function getSubject(JobIdInterface $jobId = null): TouchCommand
+    protected function getSubject(?JobIdInterface $jobId = null): TouchCommand
     {
         return new TouchCommand($jobId ?? new JobId(5));
     }

--- a/tests/Unit/Command/TubeCommandTestBase.php
+++ b/tests/Unit/Command/TubeCommandTestBase.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\Assert;
 
 abstract class TubeCommandTestBase extends CommandTestBase
 {
-    abstract protected function getSubject(TubeName $tube = null): TubeCommand;
+    abstract protected function getSubject(?TubeName $tube = null): TubeCommand;
 
     public function testInterpretNotFound(): void
     {

--- a/tests/Unit/Command/UseCommandTest.php
+++ b/tests/Unit/Command/UseCommandTest.php
@@ -30,7 +30,7 @@ final class UseCommandTest extends TubeCommandTestBase
         return [ResponseType::Using];
     }
 
-    protected function getSubject(TubeName $tube = null): UseCommand
+    protected function getSubject(?TubeName $tube = null): UseCommand
     {
         return new UseCommand($tube ?? new TubeName("default"));
     }

--- a/tests/Unit/Command/WatchCommandTest.php
+++ b/tests/Unit/Command/WatchCommandTest.php
@@ -27,7 +27,7 @@ final class WatchCommandTest extends TubeCommandTestBase
         return [ResponseType::Watching];
     }
 
-    protected function getSubject(TubeName $tube = null): WatchCommand
+    protected function getSubject(?TubeName $tube = null): WatchCommand
     {
         return new WatchCommand($tube ?? new TubeName("default"));
     }


### PR DESCRIPTION
As of PHP 8.4 implicit nullable declarations will throw a deprecation warning.

This PR updates all occurences accordingly to add a `?`-mark before the type.