### PR TITLE
chore(tests): add test for socket_create call

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,9 @@
         "ramsey/conventional-commits": "^1.2",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-phpunit": "^1.0",
-        "phpstan/phpstan-strict-rules": "^1.1"
+        "phpstan/phpstan-strict-rules": "^1.1",
+        "php-mock/php-mock": "^2.5",
+        "php-mock/php-mock-phpunit": "^2.10"
     },
     "autoload-dev": {
         "psr-4": {

--- a/tests/Unit/Socket/SocketSocketTest.php
+++ b/tests/Unit/Socket/SocketSocketTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pheanstalk\Tests\Unit\Socket;
+
+use Pheanstalk\Socket\SocketSocket;
+use Pheanstalk\Values\Timeout;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SocketSocket::class)]
+final class SocketSocketTest extends TestCase
+{
+    use \phpmock\phpunit\PHPMock;
+
+    public function testSocketCreateErrors(): void
+    {
+        $mock = $this->getFunctionMock('Pheanstalk\\Socket', 'socket_create');
+        $mock->expects($this->once())->willReturn(false);
+
+        $mock = $this->getFunctionMock('Pheanstalk\\Socket', 'socket_strerror');
+        $mock->expects($this->once())->willReturn('test message');
+        $this->expectExceptionMessageMatches('/test message/');
+
+        $socket = new SocketSocket(
+            host: "333.333.333.333",
+            port: 0,
+            connectTimeout: new Timeout(1),
+            receiveTimeout: new Timeout(1),
+            sendTimeout: new Timeout(1)
+        );
+    }
+}


### PR DESCRIPTION
This is one way of testing socket_create. It requires us to add phpmock as a dev dependency.
Unfortunately PHPMock uses deprecated mocking functions from PHPUnit 11 which I'd like to see resolved before merging this.

https://github.com/php-mock/php-mock/issues/57