### PR TITLE
Dont leave corrupted socket open

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -8,6 +8,7 @@ use Pheanstalk\Contract\CommandInterface;
 use Pheanstalk\Contract\CommandWithDataInterface;
 use Pheanstalk\Contract\SocketFactoryInterface;
 use Pheanstalk\Contract\SocketInterface;
+use Pheanstalk\Exception\ConnectionException;
 use Pheanstalk\Exception\MalformedResponseException;
 use Pheanstalk\Exception\ServerBadFormatException;
 use Pheanstalk\Exception\ServerInternalErrorException;
@@ -117,8 +118,13 @@ final class Connection
             $buffer .= $command->getData() . self::CRLF;
         }
 
-        $socket->write($buffer);
-        return $this->readRawResponse($commandLine);
+        try {
+            $socket->write($buffer);
+            return $this->readRawResponse($commandLine);
+        } catch (ConnectionException $connectionException) {
+            $socket->disconnect();
+            throw $connectionException;
+        }
     }
 
     /**


### PR DESCRIPTION
If a socket error occurs, we must ensure that the socket is not left in a half-read or half-written state. The next command should be independent and must not accidentally read leftover input.

This issue could, for example, occur due to an interrupt.