### PR TITLE
feat: add disconnect() method to release resources deterministically

### DIFF
--- a/src/Contract/PheanstalkClientInterface.php
+++ b/src/Contract/PheanstalkClientInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pheanstalk\Contract;
+
+interface PheanstalkClientInterface
+{
+    /**
+     * Closes the current connection and releases all associated resources.
+     *
+     * This method ensures that after the call, no resources are held by the client,
+     * allowing garbage collection to safely reclaim memory. If no connection is open,
+     * this method does nothing (noop). Future command dispatches will automatically
+     * establish a new connection if needed.
+     *
+     * Note: If the client has any reserved jobs at the time of disconnection, beanstalkd
+     * will automatically release them back into the ready queue.
+     */
+    public function disconnect(): void;
+}

--- a/src/Contract/PheanstalkManagerInterface.php
+++ b/src/Contract/PheanstalkManagerInterface.php
@@ -11,7 +11,7 @@ use Pheanstalk\Values\TubeList;
 use Pheanstalk\Values\TubeName;
 use Pheanstalk\Values\TubeStats;
 
-interface PheanstalkManagerInterface
+interface PheanstalkManagerInterface extends PheanstalkClientInterface
 {
     /**
      * Kicks buried or delayed jobs into a 'ready' state.
@@ -93,17 +93,4 @@ interface PheanstalkManagerInterface
      * Gives statistical information about the beanstalkd system as a whole.
      */
     public function stats(): ServerStats;
-
-    /**
-     * Closes the current connection and releases all associated resources.
-     *
-     * This method ensures that after the call, no resources are held by the client,
-     * allowing garbage collection to safely reclaim memory. If no connection is open,
-     * this method does nothing (noop). Future command dispatches will automatically
-     * establish a new connection if needed.
-     *
-     * Note: If the client has any reserved jobs at the time of disconnection, beanstalkd
-     * will automatically release them back into the ready queue.
-     */
-    public function disconnect(): void;
 }

--- a/src/Contract/PheanstalkManagerInterface.php
+++ b/src/Contract/PheanstalkManagerInterface.php
@@ -93,4 +93,17 @@ interface PheanstalkManagerInterface
      * Gives statistical information about the beanstalkd system as a whole.
      */
     public function stats(): ServerStats;
+
+    /**
+     * Closes the current connection and releases all associated resources.
+     *
+     * This method ensures that after the call, no resources are held by the client,
+     * allowing garbage collection to safely reclaim memory. If no connection is open,
+     * this method does nothing (noop). Future command dispatches will automatically
+     * establish a new connection if needed.
+     *
+     * Note: If the client has any reserved jobs at the time of disconnection, beanstalkd
+     * will automatically release them back into the ready queue.
+     */
+    public function disconnect(): void;
 }

--- a/src/Contract/PheanstalkPublisherInterface.php
+++ b/src/Contract/PheanstalkPublisherInterface.php
@@ -6,7 +6,7 @@ namespace Pheanstalk\Contract;
 
 use Pheanstalk\Values\TubeName;
 
-interface PheanstalkPublisherInterface
+interface PheanstalkPublisherInterface extends PheanstalkClientInterface
 {
     public const int DEFAULT_DELAY = 0; // no delay
     public const int DEFAULT_PRIORITY = 1024; // most urgent: 0, least urgent: 4294967295

--- a/src/Contract/PheanstalkSubscriberInterface.php
+++ b/src/Contract/PheanstalkSubscriberInterface.php
@@ -8,7 +8,7 @@ use Pheanstalk\Values\Job;
 use Pheanstalk\Values\TubeList;
 use Pheanstalk\Values\TubeName;
 
-interface PheanstalkSubscriberInterface
+interface PheanstalkSubscriberInterface extends PheanstalkClientInterface
 {
     /**
      * Permanently deletes a job.

--- a/src/Pheanstalk.php
+++ b/src/Pheanstalk.php
@@ -118,6 +118,11 @@ final class Pheanstalk implements PheanstalkManagerInterface, PheanstalkPublishe
         return $this->manager->stats();
     }
 
+    public function disconnect(): void
+    {
+        $this->manager->disconnect();
+    }
+
     public function bury(JobIdInterface $job, int $priority = self::DEFAULT_PRIORITY): void
     {
         $this->subscriber->bury($job, $priority);

--- a/src/PheanstalkManager.php
+++ b/src/PheanstalkManager.php
@@ -114,4 +114,9 @@ final class PheanstalkManager implements PheanstalkManagerInterface
         $command = new Command\StatsCommand();
         return $command->interpret($this->dispatch($command));
     }
+
+    public function disconnect(): void
+    {
+        $this->connection->disconnect();
+    }
 }

--- a/src/PheanstalkPublisher.php
+++ b/src/PheanstalkPublisher.php
@@ -40,4 +40,9 @@ final class PheanstalkPublisher implements PheanstalkPublisherInterface
         $command = new PutCommand($data, $priority, $delay, $timeToRelease);
         return $command->interpret($this->connection->dispatchCommand($command));
     }
+
+    public function disconnect(): void
+    {
+        $this->connection->disconnect();
+    }
 }

--- a/src/PheanstalkSubscriber.php
+++ b/src/PheanstalkSubscriber.php
@@ -102,4 +102,9 @@ final class PheanstalkSubscriber implements PheanstalkSubscriberInterface
         $command = new ReserveJobCommand($job);
         return $command->interpret($this->dispatch($command));
     }
+
+    public function disconnect(): void
+    {
+        $this->connection->disconnect();
+    }
 }

--- a/tests/Unit/ConnectionTest.php
+++ b/tests/Unit/ConnectionTest.php
@@ -38,6 +38,25 @@ final class ConnectionTest extends TestCase
         $connection->disconnect();
     }
 
+    public function testReconnectAfterDispatch(): void
+    {
+        $socket = $this->getMockBuilder(SocketInterface::class)->getMock();
+        $socket->expects(self::once())->method('disconnect');
+        $socket->expects(self::once())
+            ->method('getLine')
+            ->willReturn(ResponseType::Using->value);
+
+        $factory = $this->getMockBuilder(SocketFactoryInterface::class)->getMock();
+        $factory->expects(self::exactly(2))
+            ->method('create')
+            ->willReturn($socket);
+
+        $connection = new Connection($factory);
+        $connection->connect();
+        $connection->disconnect();
+        $connection->dispatchCommand(new UseCommand(new TubeName('foo')));
+    }
+
     private function getCommand(): CommandInterface
     {
         return new UseCommand(new TubeName('tube5'));


### PR DESCRIPTION
Introduces the close() method to ensure that all associated resources are released when closing a connection. This guarantees that no resources remain allocated, allowing garbage collection to reclaim memory safely. If no connection is open, the method is a noop. Future command dispatches will automatically establish a new connection if needed.

This is necessary to avoid potential resource leaks and to ensure deterministic behavior when closing a connection. In Beanstalk  released jobs are immediately enqueued when the connection is closed. This means that even if we do not care about potential memory leaks, we still want to deterministic control when exactly the connection is closed.