### PR TITLE
Backport "add disconnect() method to release resources deterministically"

### DIFF
--- a/src/Contract/PheanstalkManagerInterface.php
+++ b/src/Contract/PheanstalkManagerInterface.php
@@ -93,4 +93,14 @@ interface PheanstalkManagerInterface
      * Gives statistical information about the beanstalkd system as a whole.
      */
     public function stats(): ServerStats;
+
+    /**
+     * Closes the current connection and releases all associated resources.
+     *
+     * This method ensures that after the call, no resources are held by the client,
+     * allowing garbage collection to safely reclaim memory. If no connection is open,
+     * this method does nothing (noop). Future command dispatches will automatically
+     * establish a new connection if needed.
+     */
+    public function disconnect(): void;
 }

--- a/src/Contract/PheanstalkManagerInterface.php
+++ b/src/Contract/PheanstalkManagerInterface.php
@@ -93,14 +93,4 @@ interface PheanstalkManagerInterface
      * Gives statistical information about the beanstalkd system as a whole.
      */
     public function stats(): ServerStats;
-
-    /**
-     * Closes the current connection and releases all associated resources.
-     *
-     * This method ensures that after the call, no resources are held by the client,
-     * allowing garbage collection to safely reclaim memory. If no connection is open,
-     * this method does nothing (noop). Future command dispatches will automatically
-     * establish a new connection if needed.
-     */
-    public function disconnect(): void;
 }

--- a/src/Pheanstalk.php
+++ b/src/Pheanstalk.php
@@ -118,6 +118,11 @@ final class Pheanstalk implements PheanstalkManagerInterface, PheanstalkPublishe
         return $this->manager->stats();
     }
 
+    public function disconnect(): void
+    {
+        $this->manager->disconnect();
+    }
+
     public function bury(JobIdInterface $job, int $priority = self::DEFAULT_PRIORITY): void
     {
         $this->subscriber->bury($job, $priority);

--- a/src/Pheanstalk.php
+++ b/src/Pheanstalk.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pheanstalk;
 
+use LogicException;
 use Pheanstalk\Contract\JobIdInterface;
 use Pheanstalk\Contract\PheanstalkManagerInterface;
 use Pheanstalk\Contract\PheanstalkPublisherInterface;
@@ -120,7 +121,10 @@ final class Pheanstalk implements PheanstalkManagerInterface, PheanstalkPublishe
 
     public function disconnect(): void
     {
-        $this->manager->disconnect();
+        if ($this->manager instanceof PheanstalkManager) {
+            $this->manager->disconnect();
+        }
+        throw new LogicException('Unsupported implementation: ' . $this->manager::class);
     }
 
     public function bury(JobIdInterface $job, int $priority = self::DEFAULT_PRIORITY): void

--- a/src/PheanstalkManager.php
+++ b/src/PheanstalkManager.php
@@ -114,4 +114,9 @@ final class PheanstalkManager implements PheanstalkManagerInterface
         $command = new Command\StatsCommand();
         return $command->interpret($this->dispatch($command));
     }
+
+    public function disconnect(): void
+    {
+        $this->connection->disconnect();
+    }
 }

--- a/tests/Unit/ConnectionTest.php
+++ b/tests/Unit/ConnectionTest.php
@@ -37,6 +37,25 @@ final class ConnectionTest extends TestCase
         $connection->disconnect();
     }
 
+    public function testReconnectAfterDispatch(): void
+    {
+        $socket = $this->getMockBuilder(SocketInterface::class)->getMock();
+        $socket->expects(self::once())->method('disconnect');
+        $socket->expects(self::once())
+            ->method('getLine')
+            ->willReturn(ResponseType::Using->value);
+
+        $factory = $this->getMockBuilder(SocketFactoryInterface::class)->getMock();
+        $factory->expects(self::exactly(2))
+            ->method('create')
+            ->willReturn($socket);
+
+        $connection = new Connection($factory);
+        $connection->connect();
+        $connection->disconnect();
+        $connection->dispatchCommand(new UseCommand(new TubeName('foo')));
+    }
+
     private function getCommand(): CommandInterface
     {
         return new UseCommand(new TubeName('tube5'));


### PR DESCRIPTION
Backports the addition of the disconnect() method while ensuring compatibility 
with the current major version. Since disconnect() is a new method, no existing 
clients depend on it. However, to avoid an interface change that would 
require a major version bump, the disconnect() method has been removed 
from the interface but remains in the implementation.

Clients who want to use disconnect() should upgrade to the next major release 
rather than relying on calling it directly on the implementation.