### PR TITLE
Pass tube name to `TubeNotFoundException`

### DIFF
--- a/src/Command/PauseTubeCommand.php
+++ b/src/Command/PauseTubeCommand.php
@@ -30,7 +30,7 @@ final class PauseTubeCommand extends TubeCommand
     public function interpret(RawResponse $response): Success
     {
         return match ($response->type) {
-            ResponseType::NotFound => throw new Exception\TubeNotFoundException(),
+            ResponseType::NotFound => throw new Exception\TubeNotFoundException($this->tube),
             ResponseType::Paused => new Success(),
             default => throw new UnsupportedResponseException($response->type)
         };

--- a/src/Command/StatsTubeCommand.php
+++ b/src/Command/StatsTubeCommand.php
@@ -25,7 +25,7 @@ final class StatsTubeCommand extends TubeCommand
             return TubeStats::fromBeanstalkArray((new YamlDictionaryParser())->parse($response->data));
         }
         throw match ($response->type) {
-            ResponseType::NotFound => new TubeNotFoundException(),
+            ResponseType::NotFound => new TubeNotFoundException($this->tube),
             ResponseType::Ok => MalformedResponseException::expectedData(),
             default => new UnsupportedResponseException($response->type)
         };

--- a/src/Exception/TubeNotFoundException.php
+++ b/src/Exception/TubeNotFoundException.php
@@ -4,6 +4,27 @@ declare(strict_types=1);
 
 namespace Pheanstalk\Exception;
 
+use Pheanstalk\Values\TubeName;
+
 final class TubeNotFoundException extends ClientException
 {
+    private const string UNKNOWN_TUBE = '[unknown]';
+
+    public readonly string $tube;
+
+    public function __construct(string|TubeName $message = '', int $code = 0, ?\Throwable $previous = null)
+    {
+        if ($message instanceof TubeName) {
+            $this->tube = (string) $message;
+            $message = '';
+        } else {
+            $this->tube = self::UNKNOWN_TUBE;
+        }
+
+        parent::__construct(
+            '' === $message ? sprintf('Tube "%s" not found.', $this->tube) : $message,
+            $code,
+            $previous,
+        );
+    }
 }

--- a/tests/Unit/Command/ConcreteTubeCommandTest.php
+++ b/tests/Unit/Command/ConcreteTubeCommandTest.php
@@ -31,7 +31,7 @@ final class ConcreteTubeCommandTest extends TubeCommandTestBase
                 RawResponse $response
             ): never {
                 throw match ($response->type) {
-                    ResponseType::NotFound => new TubeNotFoundException(),
+                    ResponseType::NotFound => new TubeNotFoundException($this->tube),
                     default => new UnsupportedResponseException($response->type)
                 };
             }

--- a/tests/Unit/Command/TubeCommandTestBase.php
+++ b/tests/Unit/Command/TubeCommandTestBase.php
@@ -21,6 +21,7 @@ abstract class TubeCommandTestBase extends CommandTestBase
         if (in_array(ResponseType::NotFound, static::getSupportedResponses(), true)) {
             $command = $this->getSubject();
             $this->expectException(TubeNotFoundException::class);
+            $this->expectExceptionMessage('Tube "default" not found.');
             $command->interpret(new RawResponse(ResponseType::NotFound));
         } else {
             $this->expectNotToPerformAssertions();

--- a/tests/Unit/Exception/TubeNotFoundExceptionTest.php
+++ b/tests/Unit/Exception/TubeNotFoundExceptionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pheanstalk\Tests\Unit\Exception;
+
+use Pheanstalk\Exception\TubeNotFoundException;
+use Pheanstalk\Values\TubeName;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(TubeNotFoundException::class)]
+final class TubeNotFoundExceptionTest extends TestCase
+{
+    #[TestWith(['', 'Tube "[unknown]" not found.', '[unknown]'])]
+    #[TestWith(['Custom message', 'Custom message', '[unknown]'])]
+    #[TestWith([new TubeName('foo'), 'Tube "foo" not found.', 'foo'])]
+    public function testMessageAndTubeAreAsExpected(string|TubeName $message, string $expectedMessage, string $expectedTube): void
+    {
+        $exception = new TubeNotFoundException($message);
+
+        self::assertSame($expectedMessage, $exception->getMessage());
+        self::assertSame($expectedTube, $exception->tube);
+    }
+}


### PR DESCRIPTION
Currently, it's a bit hard to tell which tube was not found, especially when iterating over a list of tubes. For example, errors in Sentry only show "Pheanstalk\Exception\TubeNotFoundException".

This PR adds the tube name to the exception message to make debugging easier.