### PR TITLE
fix: Don't throw an exception when a signal is dispatched

### DIFF
--- a/dockerfiles/Dockerfile-phpunit
+++ b/dockerfiles/Dockerfile-phpunit
@@ -4,6 +4,7 @@ ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/do
 RUN chmod +x /usr/local/bin/install-php-extensions \
     && sync \
     && install-php-extensions \
+    pcntl \
     sockets \
     pcov
 ENTRYPOINT ["/app/vendor/bin/phpunit"]

--- a/src/Socket/SocketSocket.php
+++ b/src/Socket/SocketSocket.php
@@ -68,6 +68,9 @@ final class SocketSocket implements SocketInterface
         while ($data !== "") {
             $written = @socket_write($socket, $data);
             if ($written === false) {
+                if ($this->isInterruptedSystemCall($socket)) {
+                    continue;
+                }
                 $this->throwException($socket);
             }
             $data = substr($data, $written);
@@ -99,6 +102,9 @@ final class SocketSocket implements SocketInterface
         while (mb_strlen($buffer, '8bit') < $length) {
             $result = @socket_read($socket, $length - mb_strlen($buffer, '8bit'));
             if ($result === false) {
+                if ($this->isInterruptedSystemCall($socket)) {
+                    continue;
+                }
                 $this->throwException($socket);
             }
             $buffer .= $result;
@@ -116,6 +122,9 @@ final class SocketSocket implements SocketInterface
         while (!str_ends_with($buffer, "\n")) {
             $result = @socket_read($socket, 1024, PHP_NORMAL_READ);
             if ($result === false) {
+                if ($this->isInterruptedSystemCall($socket)) {
+                    continue;
+                }
                 $this->throwException($socket);
             }
             $buffer .= $result;
@@ -124,6 +133,11 @@ final class SocketSocket implements SocketInterface
 
 
         return rtrim($buffer);
+    }
+
+    private function isInterruptedSystemCall(Socket $socket): bool
+    {
+        return \SOCKET_EINTR === socket_last_error($socket);
     }
 
     /**


### PR DESCRIPTION
One issue I've been running into are random errors during deployment. After some digging, I found out it's caused by blocking sockets returning a `SOCKET_EINTR` error when a signal is dispatched. This then causes Pheanstalk to throw an exception, which makes graceful shutdowns via signal handlers impossible.

Here's a minimal example:

```php
use Pheanstalk\Pheanstalk;

class Worker
{
    private bool $work = true;

    public function run(): void
    {
        $pheanstalk = Pheanstalk::create('127.0.0.1');

        while ($this->work) {
            $pheanstalk->reserveWithTimeout(5);
        }
    }

    public function handle(): void
    {
        echo 'Bye', \PHP_EOL;
        $this->work = false;
    }
}

$worker = new Worker();

pcntl_async_signals(true);
pcntl_signal(\SIGINT, $worker->handle(...));

$worker->run();
```

Sending a `SIGINT` sometimes results in:

> ^CBye
> PHP Fatal error:  Uncaught Pheanstalk\Exception\ConnectionException: Socket error 4: Interrupted system call in /project/vendor/pda/pheanstalk/src/Socket/SocketSocket.php:83
> Stack trace:
> #0 /project/vendor/pda/pheanstalk/src/Socket/SocketSocket.php(124): Pheanstalk\Socket\SocketSocket->throwException()
> #1 /project/vendor/pda/pheanstalk/src/Connection.php(83): Pheanstalk\Socket\SocketSocket->getLine()
> #2 /project/vendor/pda/pheanstalk/src/Connection.php(123): Pheanstalk\Connection->readRawResponse()
> #3 /project/vendor/pda/pheanstalk/src/PheanstalkSubscriber.php(25): Pheanstalk\Connection->dispatchCommand()
> #4 /project/vendor/pda/pheanstalk/src/PheanstalkSubscriber.php(73): Pheanstalk\PheanstalkSubscriber->dispatch()
> #5 /project/vendor/pda/pheanstalk/src/Pheanstalk.php(185): Pheanstalk\PheanstalkSubscriber->reserveWithTimeout()
> #6 /project/bin/job-error-4.php(16): Pheanstalk\Pheanstalk->reserveWithTimeout()
> #7 /project/bin/job-error-4.php(32): Worker->run()
> #8 {main}
>   thrown in /project/vendor/pda/pheanstalk/src/Socket/SocketSocket.php on line 83

This PR aims to fix that by properly handling `SOCKET_EINTR` so that signal-based shutdowns work as expected.
