### PR TITLE
Fixes pheanstalk/pheanstalk#303, dead TCP connections handling.

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,16 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Parameter \\#1 \\$errno of class Pheanstalk\\\\Exception\\\\ConnectionException constructor expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Socket/StreamSocket.php
+
+		-
+			message: "#^Parameter \\#2 \\$errstr of class Pheanstalk\\\\Exception\\\\ConnectionException constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Socket/StreamSocket.php
+
+		-
 			message: "#^Parameter \\#1 \\$id of class Pheanstalk\\\\Values\\\\JobId constructor expects int\\|Pheanstalk\\\\Contract\\\\JobIdInterface\\|string, bool\\|float\\|int\\|string given\\.$#"
 			count: 1
 			path: src/Values/JobStats.php

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -16,6 +16,7 @@ use Pheanstalk\Exception\ServerOutOfMemoryException;
 use Pheanstalk\Exception\ServerUnknownCommandException;
 use Pheanstalk\Values\RawResponse;
 use Pheanstalk\Values\ResponseType;
+use Pheanstalk\Values\Timeout;
 
 /**
  * A connection to a beanstalkd server, backed by any type of socket.
@@ -75,12 +76,12 @@ final class Connection
     }
 
 
-    private function readRawResponse(string $commandLine): RawResponse
+    private function readRawResponse(string $commandLine, ?Timeout $timeout = null): RawResponse
     {
         $socket = $this->getSocket();
 
         // This is always a simple line consisting of a response type name and 0 - 2 optional numerical arguments.
-        $responseLine = $socket->getLine();
+        $responseLine = $socket->getLine($timeout);
 
 
         $responseParts = explode(' ', $responseLine);
@@ -109,7 +110,7 @@ final class Connection
         };
     }
 
-    public function dispatchCommand(CommandInterface $command): RawResponse
+    public function dispatchCommand(CommandInterface $command, ?Timeout $timeout = null): RawResponse
     {
         $socket = $this->getSocket();
         $commandLine = $command->getCommandLine();
@@ -120,7 +121,7 @@ final class Connection
 
         try {
             $socket->write($buffer);
-            return $this->readRawResponse($commandLine);
+            return $this->readRawResponse($commandLine, $timeout);
         } catch (ConnectionException $connectionException) {
             $this->disconnect();
             throw $connectionException;

--- a/src/Contract/SocketInterface.php
+++ b/src/Contract/SocketInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Pheanstalk\Contract;
 
+use Pheanstalk\Values\Timeout;
+
 interface SocketInterface
 {
     /**
@@ -20,8 +22,9 @@ interface SocketInterface
     /**
      * Reads up to the next new-line.
      * Trailing whitespace is trimmed.
+     * @param Timeout|null $readTimeout
      */
-    public function getLine(): string;
+    public function getLine(?Timeout $readTimeout = null): string;
 
     /**
      * Disconnect the socket; subsequent usage of the socket will fail.

--- a/src/PheanstalkSubscriber.php
+++ b/src/PheanstalkSubscriber.php
@@ -13,6 +13,7 @@ use Pheanstalk\Contract\PheanstalkSubscriberInterface;
 use Pheanstalk\Values\Job;
 use Pheanstalk\Values\RawResponse;
 use Pheanstalk\Values\Success;
+use Pheanstalk\Values\Timeout;
 use Pheanstalk\Values\TubeList;
 use Pheanstalk\Values\TubeName;
 
@@ -20,9 +21,9 @@ final class PheanstalkSubscriber implements PheanstalkSubscriberInterface
 {
     use StaticFactoryTrait;
 
-    private function dispatch(CommandInterface $command): RawResponse
+    private function dispatch(CommandInterface $command, ?Timeout $timeout = null): RawResponse
     {
-        return $this->connection->dispatchCommand($command);
+        return $this->connection->dispatchCommand($command, $timeout);
     }
 
     public function delete(JobIdInterface $job): void
@@ -70,7 +71,7 @@ final class PheanstalkSubscriber implements PheanstalkSubscriberInterface
     public function reserveWithTimeout(int $timeout): null|Job
     {
         $command = new Command\ReserveWithTimeoutCommand($timeout);
-        $response = $command->interpret($this->dispatch($command));
+        $response = $command->interpret($this->dispatch($command, new Timeout($timeout)));
 
         if ($response instanceof Success) {
             return null;

--- a/src/Socket/FileSocket.php
+++ b/src/Socket/FileSocket.php
@@ -21,7 +21,7 @@ abstract class FileSocket implements SocketInterface
      */
     private $socket;
 
-    protected function __construct(mixed $socket, protected Timeout $receiveTimeout)
+    protected function __construct(mixed $socket, private Timeout $receiveTimeout)
     {
         if (!is_resource($socket)) {
             throw new \InvalidArgumentException("A valid resource is required");

--- a/src/Socket/SocketSocket.php
+++ b/src/Socket/SocketSocket.php
@@ -119,19 +119,16 @@ final class SocketSocket implements SocketInterface
         $socket = $this->getSocket();
 
         $buffer = '';
-        // Reading stops at \r or \n. In case it stopped at \r we must continue reading.
-        while (!str_ends_with($buffer, "\n")) {
-            $result = @socket_read($socket, 1024, PHP_NORMAL_READ);
-            if ($result === false) {
+        do {
+            $byteRead = @socket_read($socket, 1);
+            if ($byteRead === false) {
                 if ($this->isInterruptedSystemCall($socket)) {
                     continue;
                 }
                 $this->throwException($socket);
             }
-            $buffer .= $result;
-        }
-
-
+            $buffer .= $byteRead;
+        } while ($byteRead !== "\n");
 
         return rtrim($buffer);
     }

--- a/src/Socket/SocketSocket.php
+++ b/src/Socket/SocketSocket.php
@@ -23,7 +23,7 @@ final class SocketSocket implements SocketInterface
         int $port,
         Timeout $connectTimeout,
         Timeout $sendTimeout,
-        Timeout $receiveTimeout
+        private Timeout $receiveTimeout
     ) {
         if (str_starts_with($host, 'unix://')) {
             $socket = @socket_create(AF_UNIX, SOCK_STREAM, SOL_SOCKET);
@@ -54,7 +54,7 @@ final class SocketSocket implements SocketInterface
         }
 
         socket_set_option($socket, SOL_SOCKET, SO_SNDTIMEO, $sendTimeout->toArray());
-        socket_set_option($socket, SOL_SOCKET, SO_RCVTIMEO, $receiveTimeout->toArray());
+        socket_set_option($socket, SOL_SOCKET, SO_RCVTIMEO, $this->receiveTimeout->toArray());
 
         $this->socket = $socket;
     }
@@ -114,9 +114,15 @@ final class SocketSocket implements SocketInterface
         return $buffer;
     }
 
-    public function getLine(): string
+    public function getLine(?Timeout $readTimeout = null): string
     {
         $socket = $this->getSocket();
+        socket_set_option(
+            $socket,
+            SOL_SOCKET,
+            SO_RCVTIMEO,
+            $this->receiveTimeout->add($readTimeout)->toArray()
+        );
 
         $buffer = '';
         do {
@@ -129,6 +135,8 @@ final class SocketSocket implements SocketInterface
             }
             $buffer .= $byteRead;
         } while ($byteRead !== "\n");
+
+        socket_set_option($socket, SOL_SOCKET, SO_RCVTIMEO, $this->receiveTimeout->toArray());
 
         return rtrim($buffer);
     }

--- a/src/Values/Timeout.php
+++ b/src/Values/Timeout.php
@@ -6,8 +6,19 @@ namespace Pheanstalk\Values;
 
 final class Timeout
 {
-    public function __construct(public readonly int $seconds, public readonly int $microSeconds = 0)
+    public readonly int $seconds;
+    public readonly int $microSeconds;
+
+    public function __construct(int $seconds, int $microSeconds = 0)
     {
+        $this->seconds = match (true) {
+            $seconds >= 0 => $seconds,
+            default => throw new \InvalidArgumentException('seconds value must be >= 0')
+        };
+        $this->microSeconds = match (true) {
+            $microSeconds >= 0 => $microSeconds,
+            default => throw new \InvalidArgumentException('microSeconds value must be >= 0')
+        };
     }
 
     /**

--- a/src/Values/Timeout.php
+++ b/src/Values/Timeout.php
@@ -32,6 +32,22 @@ final class Timeout
         ];
     }
 
+    /**
+     * @param Timeout|null $other
+     * @return static
+     */
+    public function add(?Timeout $other = null): static
+    {
+        if ($other === null) {
+            return clone $this;
+        }
+
+        return new static(
+            $other->seconds + $this->seconds + intval(($other->microSeconds + $this->microSeconds) / 1000000),
+            ($other->microSeconds + $this->microSeconds) % 1000000
+        );
+    }
+
     public function toFloat(): float
     {
         return $this->seconds + ($this->microSeconds / 1000000);

--- a/tests/Unit/Values/TimeoutTest.php
+++ b/tests/Unit/Values/TimeoutTest.php
@@ -4,13 +4,59 @@ declare(strict_types=1);
 
 namespace Pheanstalk\Tests\Unit\Values;
 
+use InvalidArgumentException;
 use Pheanstalk\Values\Timeout;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(Timeout::class)]
 final class TimeoutTest extends TestCase
 {
+    /**
+     * @return list<array{0: int, 1: int}|array{0: int}>
+     */
+    public static function validConstructorArguments(): array
+    {
+        return [
+            [0, ],
+            [0, 0],
+            [0, 200],
+            [100, 0],
+            [100, ],
+            [100, 200],
+        ];
+    }
+
+    /**
+     * @return list<array{0: int, 1: int}|array{0: int}>
+     */
+    public static function invalidConstructorArguments(): array
+    {
+        return [
+            [0, -200],
+            [-100, ],
+            [-100, 0],
+            [-100, -200],
+        ];
+    }
+
+    #[DataProvider('validConstructorArguments')]
+    public function testConstructorWitValidArgumentsCreatesInstance(int $seconds, int $microSeconds = 0): void
+    {
+        $timeout = new Timeout($seconds, $microSeconds);
+
+        self::assertSame($seconds, $timeout->seconds);
+        self::assertSame($microSeconds, $timeout->microSeconds);
+    }
+
+    #[DataProvider('invalidConstructorArguments')]
+    public function testConstructorWitInvalidArgumentsThrowsException(int $seconds, int $microSeconds = 0): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new Timeout($seconds, $microSeconds);
+    }
+
     public function testToFloat(): void
     {
         self::assertSame(1.5, (new Timeout(1, 500000))->toFloat());

--- a/tests/Unit/Values/TimeoutTest.php
+++ b/tests/Unit/Values/TimeoutTest.php
@@ -69,4 +69,40 @@ final class TimeoutTest extends TestCase
             'usec' => 500000
         ], (new Timeout(1, 500000))->toArray());
     }
+
+    public function testAddNullReturnsSameValue(): void
+    {
+        $timeout = (new Timeout(1, 500000))->add();
+        self::assertSame([
+            'sec' => 1,
+            'usec' => 500000
+        ], $timeout->toArray());
+    }
+
+    public function testAddWithNoMsReturnsExpectedValue(): void
+    {
+        $timeout = (new Timeout(1, 500000))->add(new Timeout(2));
+        self::assertSame([
+            'sec' => 3,
+            'usec' => 500000
+        ], $timeout->toArray());
+    }
+
+    public function testAddWithNotOverflowingMsReturnsExpectedValue(): void
+    {
+        $timeout = (new Timeout(1, 500000))->add(new Timeout(2, 200000));
+        self::assertSame([
+            'sec' => 3,
+            'usec' => 700000
+        ], $timeout->toArray());
+    }
+
+    public function testAddWithOverflowingMsReturnsExpectedValue(): void
+    {
+        $timeout = (new Timeout(1, 500000))->add(new Timeout(2, 800000));
+        self::assertSame([
+            'sec' => 4,
+            'usec' => 300000
+        ], $timeout->toArray());
+    }
 }


### PR DESCRIPTION
Dead TCP connections are not detected properly. 

Caused by PHP implementation of `socket_read()` when using `PHP_NORMAL_READ` flag. Switching to `PHP_BINARY_READ` and detecting end-of-line ( `\n` ) in our code.